### PR TITLE
Switch Talk Voice Mode to gpt-realtime-1.5 with semantic_vad

### DIFF
--- a/steelclaw/api/voice.py
+++ b/steelclaw/api/voice.py
@@ -327,18 +327,28 @@ async def create_realtime_session(
     parts = [p for p in [persona_prompt, system_prompt, memory_context] if p]
     full_instructions = "\n\n".join(parts)
 
+    vad_type = getattr(voice_settings, "realtime_vad_type", "semantic_vad")
+    if vad_type == "semantic_vad":
+        turn_detection = {
+            "type": "semantic_vad",
+            "eagerness": getattr(voice_settings, "realtime_vad_eagerness", "auto"),
+            "prefix_padding_ms": voice_settings.realtime_prefix_padding_ms,
+        }
+    else:
+        turn_detection = {
+            "type": "server_vad",
+            "threshold": voice_settings.realtime_vad_threshold,
+            "silence_duration_ms": voice_settings.realtime_silence_ms,
+            "prefix_padding_ms": voice_settings.realtime_prefix_padding_ms,
+        }
+
     payload = {
         "model": voice_settings.realtime_model,
         "modalities": ["audio", "text"],
         "voice": body.voice or voice_settings.realtime_voice,
         "instructions": full_instructions,
         "input_audio_transcription": {"model": "whisper-1"},
-        "turn_detection": {
-            "type": "server_vad",
-            "threshold": voice_settings.realtime_vad_threshold,
-            "silence_duration_ms": voice_settings.realtime_silence_ms,
-            "prefix_padding_ms": voice_settings.realtime_prefix_padding_ms,
-        },
+        "turn_detection": turn_detection,
     }
 
     async with httpx.AsyncClient() as client:

--- a/steelclaw/settings.py
+++ b/steelclaw/settings.py
@@ -118,8 +118,10 @@ class VoiceSettings(BaseModel):
     stt_provider: str = "openai"
     tts_provider: str = "openai"
     enabled: bool = False
-    realtime_model: str = "gpt-4o-realtime-preview"
+    realtime_model: str = "gpt-realtime-1.5"
     realtime_voice: str = "alloy"
+    realtime_vad_type: str = "semantic_vad"
+    realtime_vad_eagerness: str = "auto"
     realtime_vad_threshold: float = 0.5
     realtime_silence_ms: int = 600
     realtime_prefix_padding_ms: int = 300

--- a/steelclaw/web/static/voice-mode.js
+++ b/steelclaw/web/static/voice-mode.js
@@ -37,7 +37,7 @@ class VoiceModeManager {
     this._currentAgentTurn = '';
 
     /** @type {string} Model name resolved from session response */
-    this._model = 'gpt-4o-realtime-preview';
+    this._model = 'gpt-realtime-1.5';
 
     this._voice = localStorage.getItem('steelclaw-realtime-voice') || 'alloy';
 
@@ -195,7 +195,7 @@ class VoiceModeManager {
     }
     return {
       clientSecret: data.client_secret.value,
-      model: data.model || 'gpt-4o-realtime-preview',
+      model: data.model || 'gpt-realtime-1.5',
       sessionId: data.session_id || '',
     };
   }

--- a/tests/test_voice_stream.py
+++ b/tests/test_voice_stream.py
@@ -34,8 +34,10 @@ def test_split_empty():
 
 def test_voice_settings_realtime_defaults():
     s = VoiceSettings()
-    assert s.realtime_model == "gpt-4o-realtime-preview"
+    assert s.realtime_model == "gpt-realtime-1.5"
     assert s.realtime_voice == "alloy"
+    assert s.realtime_vad_type == "semantic_vad"
+    assert s.realtime_vad_eagerness == "auto"
     assert s.realtime_vad_threshold == 0.5
     assert s.realtime_silence_ms == 600
     assert s.realtime_prefix_padding_ms == 300
@@ -51,8 +53,10 @@ def _make_voice_settings():
             llm=LLMSettings(api_key="sk-test-key"),
             voice=VoiceSettings(
                 enabled=True,
-                realtime_model="gpt-4o-realtime-preview",
+                realtime_model="gpt-realtime-1.5",
                 realtime_voice="alloy",
+                realtime_vad_type="semantic_vad",
+                realtime_vad_eagerness="auto",
                 realtime_vad_threshold=0.5,
                 realtime_silence_ms=600,
                 realtime_prefix_padding_ms=300,
@@ -108,7 +112,7 @@ async def test_realtime_session_success(voice_client):
     mock_resp.json.return_value = {
         "id": "sess_abc123",
         "client_secret": {"value": "ek_test_token"},
-        "model": "gpt-4o-realtime-preview",
+        "model": "gpt-realtime-1.5",
     }
 
     with patch("steelclaw.api.voice.httpx.AsyncClient") as MockClient:
@@ -126,7 +130,7 @@ async def test_realtime_session_success(voice_client):
     data = resp.json()
     assert data["session_id"] == "sess_abc123"
     assert data["client_secret"]["value"] == "ek_test_token"
-    assert data["model"] == "gpt-4o-realtime-preview"
+    assert data["model"] == "gpt-realtime-1.5"
 
 
 async def test_realtime_session_openai_error(voice_client):
@@ -156,7 +160,7 @@ async def test_realtime_session_uses_agent_system_prompt(voice_client):
     mock_resp.json.return_value = {
         "id": "sess_xyz",
         "client_secret": {"value": "ek_xyz"},
-        "model": "gpt-4o-realtime-preview",
+        "model": "gpt-realtime-1.5",
     }
     captured = {}
 
@@ -179,6 +183,39 @@ async def test_realtime_session_uses_agent_system_prompt(voice_client):
     assert len(captured["payload"]["instructions"]) > 0
 
 
+async def test_realtime_session_uses_semantic_vad(voice_client):
+    """Verifies semantic_vad turn detection is sent to OpenAI for gpt-realtime-1.5."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "id": "sess_vad",
+        "client_secret": {"value": "ek_vad"},
+        "model": "gpt-realtime-1.5",
+    }
+    captured = {}
+
+    async def capture_post(url, **kwargs):
+        captured["payload"] = kwargs.get("json", {})
+        return mock_resp
+
+    with patch("steelclaw.api.voice.httpx.AsyncClient") as MockClient:
+        instance = AsyncMock()
+        MockClient.return_value.__aenter__.return_value = instance
+        instance.post.side_effect = capture_post
+
+        await voice_client.post(
+            "/api/voice/realtime-session",
+            json={},
+            headers={"Content-Type": "application/json"},
+        )
+
+    td = captured.get("payload", {}).get("turn_detection", {})
+    assert td.get("type") == "semantic_vad"
+    assert td.get("eagerness") == "auto"
+    assert "threshold" not in td
+    assert "silence_duration_ms" not in td
+
+
 async def test_realtime_session_injects_memory(voice_app_and_client):
     """Instructions must include formatted memory context when retriever is set."""
     app, ac = voice_app_and_client
@@ -193,7 +230,7 @@ async def test_realtime_session_injects_memory(voice_app_and_client):
     mock_resp.json.return_value = {
         "id": "sess_m1",
         "client_secret": {"value": "ek_m1"},
-        "model": "gpt-4o-realtime-preview",
+        "model": "gpt-realtime-1.5",
     }
     captured = {}
 
@@ -232,7 +269,7 @@ async def test_realtime_session_injects_persona(voice_client):
     mock_resp.json.return_value = {
         "id": "sess_p1",
         "client_secret": {"value": "ek_p1"},
-        "model": "gpt-4o-realtime-preview",
+        "model": "gpt-realtime-1.5",
     }
     captured = {}
 


### PR DESCRIPTION
- Update default realtime_model from gpt-4o-realtime-preview to gpt-realtime-1.5
- Add realtime_vad_type (default: semantic_vad) and realtime_vad_eagerness (default: auto) to VoiceSettings
- Update voice.py to send semantic_vad turn_detection payload (with eagerness) for gpt-realtime-1.5; falls back to server_vad for legacy configs
- Update JS fallback model references in voice-mode.js
- Update tests to reflect new model and add semantic_vad payload assertion

https://claude.ai/code/session_01XpzTjbRgN4wPeC2yWqhfQX