### PR TITLE
feat: ASCII startup animation & static logo for terminal (closes #11)

### DIFF
--- a/steelclaw/__main__.py
+++ b/steelclaw/__main__.py
@@ -9,9 +9,11 @@ import sys
 
 def _show_banner() -> None:
     """Show ASCII banner unless --no-banner is passed."""
-    if "--no-banner" not in sys.argv:
-        from steelclaw.cli.banner import print_banner
-        print_banner()
+    if "--no-banner" in sys.argv:
+        return
+    from steelclaw.cli.banner import print_banner
+    static_only = "--static-logo" in sys.argv
+    print_banner(animated=not static_only)
 
 
 # ── Server commands ─────────────────────────────────────────────────────────
@@ -195,6 +197,7 @@ def main() -> None:
         description="SteelClaw — self-hosted personal AI assistant",
     )
     parser.add_argument("--no-banner", action="store_true", help="Suppress the startup banner")
+    parser.add_argument("--static-logo", action="store_true", help="Show static logo without animation")
     sub = parser.add_subparsers(dest="command")
 
     # serve

--- a/steelclaw/cli/banner.py
+++ b/steelclaw/cli/banner.py
@@ -2,22 +2,133 @@
 
 from __future__ import annotations
 
-BANNER = (
-    "\033[96m"
-    r"""
-   ______          __  _______
-  / __/ /____ ___ / / / ___/ /__ _    __
- _\ \/ __/ -_) -_) / / /__/ / _ `/ |/| /
-/___/\__/\__/\__/_/  \___/_/\_,_/|__/|__/
+import os
+import sys
+import time
 
-    ╔═══════════════════════════════════╗
-    ║  ⚙  Autonomous AI Agent Engine  ⚙  ║
-    ╚═══════════════════════════════════╝
-"""
-    "\033[0m"
-)
+_LOGO_LINES = [
+    r"   ______          __  _______",
+    r"  / __/ /____ ___ / / / ___/ /__ _    __",
+    r" _\ \/ __/ -_) -_) / / /__/ / _ `/ |/| /",
+    r"/___/\__/\__/\__/_/  \___/_/\_,_/|__/|__/",
+]
+
+_TAGLINE_BOX = [
+    "    ╔═══════════════════════════════════╗",
+    "    ║  ⚙  Autonomous AI Agent Engine  ⚙  ║",
+    "    ╚═══════════════════════════════════╝",
+]
 
 
-def print_banner() -> None:
-    """Print the SteelClaw banner in cyan. Call before argparse runs."""
-    print(BANNER)
+def _use_color() -> bool:
+    """Return True if color output should be used."""
+    if os.environ.get("NO_COLOR"):
+        return False
+    if not sys.stdout.isatty():
+        return False
+    return True
+
+
+def _use_animation() -> bool:
+    """Return True if animation should be shown (TTY, not NO_COLOR, not CI)."""
+    if not sys.stdout.isatty():
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("CI"):
+        return False
+    return True
+
+
+def _get_version() -> str:
+    try:
+        from importlib.metadata import version
+        return version("steelclaw")
+    except Exception:
+        pass
+    try:
+        from steelclaw import __version__
+        return __version__
+    except Exception:
+        return "0.3.0"
+
+
+def _print_static(color: bool = True) -> None:
+    """Print the full static banner."""
+    cyan = "\033[96m" if color else ""
+    reset = "\033[0m" if color else ""
+    dim = "\033[2m" if color else ""
+
+    version = _get_version()
+
+    print(cyan)
+    for line in _LOGO_LINES:
+        print(line)
+    print()
+    for line in _TAGLINE_BOX:
+        print(line)
+    print(reset, end="")
+    print(f"{dim}  v{version}  |  Run `steelclaw --help` for usage{reset}")
+    print()
+
+
+def _animate_typewriter(color: bool = True) -> None:
+    """Typewriter reveal: print each logo line character by character."""
+    cyan = "\033[96m" if color else ""
+    reset = "\033[0m" if color else ""
+    dim = "\033[2m" if color else ""
+
+    version = _get_version()
+
+    # Total animation budget: ~1.5 s for logo lines, rest for tagline
+    all_lines = _LOGO_LINES + [""] + _TAGLINE_BOX
+    total_chars = sum(len(l) for l in all_lines)
+    delay = 1.5 / max(total_chars, 1)
+
+    print(cyan, end="", flush=True)
+    for line in _LOGO_LINES:
+        for ch in line:
+            sys.stdout.write(ch)
+            sys.stdout.flush()
+            time.sleep(delay)
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
+    print()
+
+    for line in _TAGLINE_BOX:
+        for ch in line:
+            sys.stdout.write(ch)
+            sys.stdout.flush()
+            time.sleep(delay)
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
+    print(reset, end="")
+    print(f"{dim}  v{version}  |  Run `steelclaw --help` for usage{reset}")
+    print()
+
+
+def print_banner(animated: bool = True) -> None:
+    """Print the SteelClaw startup banner.
+
+    Parameters
+    ----------
+    animated:
+        When *True* (default) a typewriter animation is shown in interactive
+        TTY sessions.  Animations are automatically disabled when ``NO_COLOR``
+        is set, when stdout is not a TTY, or when the ``CI`` variable is set.
+        Pass *False* to always show the static logo (equivalent to
+        ``--static-logo``).
+    """
+    color = _use_color()
+
+    if animated and _use_animation():
+        try:
+            _animate_typewriter(color=color)
+        except KeyboardInterrupt:
+            # User pressed Ctrl-C to skip animation — fall back to static
+            sys.stdout.write("\n")
+            _print_static(color=color)
+    else:
+        _print_static(color=color)

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -1,0 +1,245 @@
+"""Tests for the CLI banner module."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import time
+from unittest import mock
+
+import pytest
+
+from steelclaw.cli.banner import (
+    _use_animation,
+    _use_color,
+    _get_version,
+    _print_static,
+    _animate_typewriter,
+    print_banner,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper guards
+# ---------------------------------------------------------------------------
+
+class _FakeTTY(io.StringIO):
+    """StringIO that claims to be a TTY."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+class _FakeNonTTY(io.StringIO):
+    """StringIO that is NOT a TTY."""
+
+    def isatty(self) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# _use_color
+# ---------------------------------------------------------------------------
+
+def test_use_color_tty(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    assert _use_color() is True
+
+
+def test_use_color_no_color_env(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    assert _use_color() is False
+
+
+def test_use_color_non_tty(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(sys, "stdout", _FakeNonTTY())
+    assert _use_color() is False
+
+
+# ---------------------------------------------------------------------------
+# _use_animation
+# ---------------------------------------------------------------------------
+
+def test_use_animation_tty(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    assert _use_animation() is True
+
+
+def test_use_animation_no_color(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    assert _use_animation() is False
+
+
+def test_use_animation_ci(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    assert _use_animation() is False
+
+
+def test_use_animation_non_tty(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(sys, "stdout", _FakeNonTTY())
+    assert _use_animation() is False
+
+
+# ---------------------------------------------------------------------------
+# _get_version
+# ---------------------------------------------------------------------------
+
+def test_get_version_returns_string():
+    v = _get_version()
+    assert isinstance(v, str)
+    assert len(v) > 0
+
+
+def test_get_version_fallback(monkeypatch):
+    """If importlib.metadata fails, fall back gracefully."""
+    import importlib.metadata as _meta
+
+    monkeypatch.setattr(_meta, "version", mock.Mock(side_effect=Exception("nope")))
+    # Also patch the steelclaw __version__ import path
+    with mock.patch.dict("sys.modules", {"steelclaw": mock.MagicMock(__version__="9.9.9")}):
+        v = _get_version()
+    assert isinstance(v, str)
+
+
+# ---------------------------------------------------------------------------
+# _print_static
+# ---------------------------------------------------------------------------
+
+def test_print_static_contains_logo(capsys):
+    _print_static(color=False)
+    out = capsys.readouterr().out
+    assert "SteelClaw" in out or "___" in out or "__/" in out
+
+
+def test_print_static_contains_version(capsys):
+    _print_static(color=False)
+    out = capsys.readouterr().out
+    assert "v" in out  # version string starts with 'v'
+
+
+def test_print_static_contains_tagline(capsys):
+    _print_static(color=False)
+    out = capsys.readouterr().out
+    assert "Autonomous AI Agent Engine" in out
+
+
+def test_print_static_contains_help_hint(capsys):
+    _print_static(color=False)
+    out = capsys.readouterr().out
+    assert "--help" in out
+
+
+def test_print_static_no_escape_codes_when_no_color(capsys):
+    _print_static(color=False)
+    out = capsys.readouterr().out
+    assert "\033[" not in out
+
+
+def test_print_static_escape_codes_with_color(capsys):
+    _print_static(color=True)
+    out = capsys.readouterr().out
+    assert "\033[" in out
+
+
+# ---------------------------------------------------------------------------
+# _animate_typewriter
+# ---------------------------------------------------------------------------
+
+def test_animate_typewriter_output(capsys, monkeypatch):
+    # Speed up by patching time.sleep to a no-op
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    _animate_typewriter(color=False)
+    out = capsys.readouterr().out
+    assert "Autonomous AI Agent Engine" in out
+    assert "--help" in out
+
+
+def test_animate_typewriter_keyboard_interrupt_handled(capsys, monkeypatch):
+    """KeyboardInterrupt mid-animation should be handled in print_banner."""
+    call_count = 0
+
+    def _raise_on_second(*_):
+        nonlocal call_count
+        call_count += 1
+        if call_count > 5:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(time, "sleep", _raise_on_second)
+    # Make stdout appear as a TTY so animation path is taken
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+    # Should not raise — KeyboardInterrupt is caught and fallback shown
+    print_banner(animated=True)
+
+
+# ---------------------------------------------------------------------------
+# print_banner
+# ---------------------------------------------------------------------------
+
+def test_print_banner_static_when_not_animated(capsys, monkeypatch):
+    # Don't replace sys.stdout so capsys can capture; just disable animation
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    print_banner(animated=False)
+    out = capsys.readouterr().out
+    assert "Autonomous AI Agent Engine" in out
+
+
+def test_print_banner_animated_false_skips_animation(capsys, monkeypatch):
+    """When animated=False, no time.sleep calls should occur."""
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    sleep_calls = []
+    monkeypatch.setattr(time, "sleep", lambda d: sleep_calls.append(d))
+
+    print_banner(animated=False)
+    assert sleep_calls == [], "Static banner must not call time.sleep"
+
+
+def test_print_banner_animated_true_on_tty(capsys, monkeypatch):
+    """When animated=True on a TTY, time.sleep should be called."""
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    sleep_calls = []
+    monkeypatch.setattr(time, "sleep", lambda d: sleep_calls.append(d))
+
+    print_banner(animated=True)
+    assert len(sleep_calls) > 0, "Animated banner must call time.sleep"
+
+
+def test_print_banner_no_animation_in_ci(capsys, monkeypatch):
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    sleep_calls = []
+    monkeypatch.setattr(time, "sleep", lambda d: sleep_calls.append(d))
+
+    print_banner(animated=True)
+    assert sleep_calls == [], "CI env should disable animation"
+
+
+def test_print_banner_no_animation_with_no_color(capsys, monkeypatch):
+    monkeypatch.setattr(sys, "stdout", _FakeTTY())
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.delenv("CI", raising=False)
+    sleep_calls = []
+    monkeypatch.setattr(time, "sleep", lambda d: sleep_calls.append(d))
+
+    print_banner(animated=True)
+    assert sleep_calls == [], "NO_COLOR should disable animation"


### PR DESCRIPTION
- Add typewriter animation to banner (character-by-character reveal, ~1.5s)
- Respect NO_COLOR env var and non-TTY contexts (static fallback)
- Disable animation in CI environments automatically
- Show version number, tagline box, and --help hint below the logo
- Add --static-logo CLI flag to skip animation and show static logo only
- KeyboardInterrupt during animation falls back gracefully to static logo
- Add 22 tests covering color/animation guards, static output, animation,
  and all print_banner code paths

https://claude.ai/code/session_01Uwfj8eaWNwHL97adGfwDBv