### PR TITLE
feat: replace typewriter animation with dollar-sign ASCII logo + box frame

### DIFF
--- a/steelclaw/gateway/base.py
+++ b/steelclaw/gateway/base.py
@@ -28,6 +28,7 @@ class BaseConnector(ABC):
         self.last_error: str | None = None
 
     async def start(self) -> None:
+        await self.register_commands()
         self._task = asyncio.create_task(self._run(), name=f"connector-{self.platform_name}")
         logger.info("Connector %s started", self.platform_name)
 
@@ -66,6 +67,16 @@ class BaseConnector(ABC):
     async def send(self, message: OutboundMessage) -> None:
         """Translate an ``OutboundMessage`` into the platform's native API call."""
         ...
+
+    async def register_commands(self) -> None:
+        """Register slash commands with the platform for autocomplete menus.
+
+        Subclasses override this to call their platform's command-registration
+        API (e.g. Telegram setMyCommands, Discord application commands).
+        The default implementation is a no-op so connectors that don't support
+        slash command registration are unaffected.
+        """
+        pass
 
     async def send_typing(self, chat_id: str) -> None:
         """Send a one-shot typing indicator. Override in subclasses that support it."""

--- a/steelclaw/gateway/commands.py
+++ b/steelclaw/gateway/commands.py
@@ -1,0 +1,49 @@
+"""Centralized slash command registry for all messenger platform connectors.
+
+Each entry exposes:
+  name        – command name without the leading slash
+  description – short human-readable description shown in autocomplete menus
+  params      – optional list of parameter hints (informational only)
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class SlashCommand(TypedDict, total=False):
+    name: str
+    description: str
+    params: list[str]
+
+
+# Commands mirroring the SteelClaw CLI and core capabilities.
+SLASH_COMMANDS: list[SlashCommand] = [
+    {
+        "name": "help",
+        "description": "Show available commands and usage information",
+    },
+    {
+        "name": "status",
+        "description": "Show current bot and session status",
+    },
+    {
+        "name": "run",
+        "description": "Run a task or shell command",
+        "params": ["task"],
+    },
+    {
+        "name": "stop",
+        "description": "Stop the current running task",
+    },
+    {
+        "name": "config",
+        "description": "View or update bot configuration",
+        "params": ["key", "value"],
+    },
+    {
+        "name": "memory",
+        "description": "Manage persistent memory (list, clear, search)",
+        "params": ["action"],
+    },
+]

--- a/steelclaw/gateway/connectors/discord.py
+++ b/steelclaw/gateway/connectors/discord.py
@@ -9,9 +9,12 @@ import httpx
 
 from steelclaw.gateway.base import BaseConnector
 from steelclaw.gateway.attachments import build_attachment_dict, transcribe_audio_attachment
+from steelclaw.gateway.commands import SLASH_COMMANDS
 from steelclaw.schemas.messages import InboundMessage, OutboundMessage
 
 logger = logging.getLogger("steelclaw.gateway.discord")
+
+_DISCORD_API = "https://discord.com/api/v10"
 
 
 class DiscordConnector(BaseConnector):
@@ -20,6 +23,48 @@ class DiscordConnector(BaseConnector):
     def __init__(self, config, handler) -> None:
         super().__init__(config, handler)
         self._client = None
+
+    async def register_commands(self) -> None:
+        """Register global slash commands with Discord via the Application Commands REST API.
+
+        Fetches the application ID from the ``/users/@me`` endpoint then calls
+        ``/applications/{id}/commands`` to bulk-overwrite the global command list.
+        """
+        token = self.config.token
+        if not token:
+            return
+
+        headers = {"Authorization": f"Bot {token}"}
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                # Resolve application (bot) ID
+                me_resp = await client.get(f"{_DISCORD_API}/users/@me", headers=headers)
+                me_resp.raise_for_status()
+                application_id = me_resp.json().get("id")
+                if not application_id:
+                    logger.warning("Discord: could not resolve application ID, skipping command registration")
+                    return
+
+                # Build command payload (CHAT_INPUT = type 1)
+                commands = [
+                    {"name": cmd["name"], "description": cmd["description"], "type": 1}
+                    for cmd in SLASH_COMMANDS
+                ]
+
+                # Bulk-overwrite global application commands
+                resp = await client.put(
+                    f"{_DISCORD_API}/applications/{application_id}/commands",
+                    headers=headers,
+                    json=commands,
+                )
+                resp.raise_for_status()
+                logger.info(
+                    "Discord: registered %d global slash commands (application_id=%s)",
+                    len(commands),
+                    application_id,
+                )
+        except Exception:
+            logger.exception("Discord: failed to register slash commands")
 
     async def _run(self) -> None:
         try:

--- a/steelclaw/gateway/connectors/slack.py
+++ b/steelclaw/gateway/connectors/slack.py
@@ -10,6 +10,7 @@ import httpx
 
 from steelclaw.gateway.base import BaseConnector
 from steelclaw.gateway.attachments import build_attachment_dict, transcribe_audio_attachment
+from steelclaw.gateway.commands import SLASH_COMMANDS
 from steelclaw.schemas.messages import InboundMessage, OutboundMessage
 
 logger = logging.getLogger("steelclaw.gateway.slack")
@@ -20,6 +21,19 @@ _HANDLED_SUBTYPES = frozenset({"file_share"})
 
 class SlackConnector(BaseConnector):
     platform_name = "slack"
+
+    async def register_commands(self) -> None:
+        """Log the slash commands that must be configured in the Slack app manifest.
+
+        Slack slash commands are registered via the app configuration (App Manifest /
+        Slash Commands settings page) rather than at runtime via the API.  This method
+        emits an INFO log listing every command so that operators know exactly which
+        commands to add when setting up the Slack app.
+        """
+        names = ", ".join(f"/{cmd['name']}" for cmd in SLASH_COMMANDS)
+        logger.info(
+            "Slack: configure the following slash commands in your Slack app settings: %s", names
+        )
 
     async def verify(self) -> str | None:
         """Validate Slack tokens via auth.test before starting the connector."""
@@ -137,6 +151,11 @@ class SlackConnector(BaseConnector):
                     subtype,
                 )
 
+                # Handle incoming slash command invocations
+                if isinstance(event_payload, dict) and event_payload.get("type") == "slash_commands":
+                    await self._handle_slash_command(event_payload)
+                    continue
+
                 # Handle regular messages and file_share subtypes; ignore bot messages and other subtypes
                 is_handled_subtype = subtype in _HANDLED_SUBTYPES
                 if (
@@ -181,6 +200,45 @@ class SlackConnector(BaseConnector):
                         is_mention="<@" in text,
                     )
                     await self.dispatch(inbound)
+
+    async def _handle_slash_command(self, payload: dict) -> None:
+        """Dispatch an incoming Slack slash command as a regular inbound message.
+
+        Slack delivers slash command invocations (e.g. ``/help``) as a
+        ``slash_commands`` payload over Socket Mode.  We normalise these into an
+        :class:`InboundMessage` so the agent pipeline handles them identically to
+        plain text messages.
+        """
+        command = payload.get("command", "")        # e.g. "/help"
+        text = payload.get("text", "").strip()      # arguments after the command
+        channel_id = payload.get("channel_id", "")
+        user_id = payload.get("user_id", "")
+        username = payload.get("user_name", "")
+        trigger_id = payload.get("trigger_id", "")
+
+        # Build a natural-language content string from the slash command
+        content = command if not text else f"{command} {text}"
+
+        logger.info(
+            "Slack slash command: command=%s text=%r channel=%s user=%s trigger_id=%s",
+            command,
+            text,
+            channel_id,
+            user_id,
+            trigger_id,
+        )
+
+        inbound = InboundMessage(
+            platform="slack",
+            platform_chat_id=channel_id,
+            platform_user_id=user_id,
+            platform_username=username,
+            platform_message_id=trigger_id,
+            content=content,
+            is_group=False,
+            is_mention=False,
+        )
+        await self.dispatch(inbound)
 
     async def send(self, message: OutboundMessage) -> None:
         token = self.config.token

--- a/steelclaw/gateway/connectors/telegram.py
+++ b/steelclaw/gateway/connectors/telegram.py
@@ -9,6 +9,7 @@ import os
 
 from steelclaw.gateway.base import BaseConnector
 from steelclaw.gateway.attachments import build_attachment_dict, transcribe_audio_attachment
+from steelclaw.gateway.commands import SLASH_COMMANDS
 from steelclaw.schemas.messages import InboundMessage, OutboundMessage
 
 logger = logging.getLogger("steelclaw.gateway.telegram")
@@ -20,6 +21,36 @@ class TelegramConnector(BaseConnector):
     def __init__(self, config, handler) -> None:
         super().__init__(config, handler)
         self._offset = 0
+
+    async def register_commands(self) -> None:
+        """Register slash commands with Telegram via setMyCommands API."""
+        import httpx
+
+        token = self.config.token
+        if not token:
+            return
+
+        commands = [
+            {"command": cmd["name"], "description": cmd["description"]}
+            for cmd in SLASH_COMMANDS
+        ]
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(
+                    f"https://api.telegram.org/bot{token}/setMyCommands",
+                    json={"commands": commands},
+                )
+                data = resp.json()
+                if data.get("ok"):
+                    logger.info(
+                        "Telegram: registered %d slash commands via setMyCommands", len(commands)
+                    )
+                else:
+                    logger.warning(
+                        "Telegram: setMyCommands failed: %s", data.get("description", data)
+                    )
+        except Exception:
+            logger.exception("Telegram: failed to register slash commands")
 
     async def _run(self) -> None:
         import httpx

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -1,0 +1,294 @@
+"""Tests for slash command registration and handling across connectors."""
+
+from __future__ import annotations
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from steelclaw.gateway.commands import SLASH_COMMANDS
+from steelclaw.settings import ConnectorConfig
+
+
+# ── Command registry ─────────────────────────────────────────────────────────
+
+
+def test_slash_commands_not_empty():
+    assert len(SLASH_COMMANDS) > 0
+
+
+def test_slash_commands_have_required_fields():
+    for cmd in SLASH_COMMANDS:
+        assert "name" in cmd, f"Missing 'name' in {cmd}"
+        assert "description" in cmd, f"Missing 'description' in {cmd}"
+        assert cmd["name"], "Command name must not be empty"
+        assert cmd["description"], "Command description must not be empty"
+
+
+def test_slash_commands_include_core_commands():
+    names = {cmd["name"] for cmd in SLASH_COMMANDS}
+    for expected in ("help", "status", "run", "stop", "config", "memory"):
+        assert expected in names, f"Expected command /{expected} not found in registry"
+
+
+def test_slash_commands_names_have_no_slash_prefix():
+    for cmd in SLASH_COMMANDS:
+        assert not cmd["name"].startswith("/"), (
+            f"Command name '{cmd['name']}' must not include a leading slash"
+        )
+
+
+# ── Telegram register_commands ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_telegram_register_commands_calls_set_my_commands():
+    from steelclaw.gateway.connectors.telegram import TelegramConnector
+
+    config = ConnectorConfig(enabled=True, token="test-token")
+    connector = TelegramConnector(config=config, handler=AsyncMock())
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"ok": True, "result": True}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client.post.return_value = mock_response
+
+        await connector.register_commands()
+
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        url = call_args[0][0] if call_args[0] else call_args.kwargs.get("url", "")
+        assert "setMyCommands" in url
+        payload = call_args.kwargs.get("json") or call_args[1].get("json", {})
+        assert "commands" in payload
+        assert len(payload["commands"]) == len(SLASH_COMMANDS)
+
+
+@pytest.mark.asyncio
+async def test_telegram_register_commands_no_token():
+    from steelclaw.gateway.connectors.telegram import TelegramConnector
+
+    config = ConnectorConfig(enabled=True, token=None)
+    connector = TelegramConnector(config=config, handler=AsyncMock())
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        await connector.register_commands()
+        # Should return early without making any HTTP calls
+        mock_client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_telegram_register_commands_api_failure_logs_warning(caplog):
+    from steelclaw.gateway.connectors.telegram import TelegramConnector
+    import logging
+
+    config = ConnectorConfig(enabled=True, token="test-token")
+    connector = TelegramConnector(config=config, handler=AsyncMock())
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"ok": False, "description": "Unauthorized"}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client.post.return_value = mock_response
+
+        with caplog.at_level(logging.WARNING, logger="steelclaw.gateway.telegram"):
+            await connector.register_commands()
+
+    assert any("setMyCommands" in r.message for r in caplog.records)
+
+
+# ── Discord register_commands ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_discord_register_commands_calls_application_commands_api():
+    from steelclaw.gateway.connectors.discord import DiscordConnector
+
+    config = ConnectorConfig(enabled=True, token="Bot test-token")
+    connector = DiscordConnector(config=config, handler=AsyncMock())
+
+    me_response = MagicMock()
+    me_response.json.return_value = {"id": "123456789"}
+    me_response.raise_for_status = MagicMock()
+
+    put_response = MagicMock()
+    put_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client.get.return_value = me_response
+        mock_client.put.return_value = put_response
+
+        await connector.register_commands()
+
+        # Should have fetched bot identity
+        mock_client.get.assert_called_once()
+        get_url = mock_client.get.call_args[0][0]
+        assert "/users/@me" in get_url
+
+        # Should have registered commands
+        mock_client.put.assert_called_once()
+        put_url = mock_client.put.call_args[0][0]
+        assert "123456789" in put_url
+        assert "/commands" in put_url
+
+        payload = mock_client.put.call_args.kwargs.get("json") or mock_client.put.call_args[1].get("json", [])
+        assert len(payload) == len(SLASH_COMMANDS)
+        for cmd in payload:
+            assert cmd["type"] == 1  # CHAT_INPUT
+
+
+@pytest.mark.asyncio
+async def test_discord_register_commands_no_token():
+    from steelclaw.gateway.connectors.discord import DiscordConnector
+
+    config = ConnectorConfig(enabled=True, token=None)
+    connector = DiscordConnector(config=config, handler=AsyncMock())
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        await connector.register_commands()
+        mock_client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_discord_register_commands_missing_application_id_skips(caplog):
+    from steelclaw.gateway.connectors.discord import DiscordConnector
+    import logging
+
+    config = ConnectorConfig(enabled=True, token="test-token")
+    connector = DiscordConnector(config=config, handler=AsyncMock())
+
+    me_response = MagicMock()
+    me_response.json.return_value = {}  # no 'id' field
+    me_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        mock_client.get.return_value = me_response
+
+        with caplog.at_level(logging.WARNING, logger="steelclaw.gateway.discord"):
+            await connector.register_commands()
+
+        # put() should NOT be called when application_id is absent
+        mock_client.put.assert_not_called()
+
+
+# ── Slack register_commands ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_slack_register_commands_logs_command_names(caplog):
+    from steelclaw.gateway.connectors.slack import SlackConnector
+    import logging
+
+    config = ConnectorConfig(enabled=True, token="xoxb-test")
+    connector = SlackConnector(config=config, handler=AsyncMock())
+
+    with caplog.at_level(logging.INFO, logger="steelclaw.gateway.slack"):
+        await connector.register_commands()
+
+    combined = " ".join(r.message for r in caplog.records)
+    for cmd in SLASH_COMMANDS:
+        assert f"/{cmd['name']}" in combined, (
+            f"/{cmd['name']} not mentioned in Slack register_commands log output"
+        )
+
+
+# ── Slack slash command dispatch ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_slack_handle_slash_command_dispatches_inbound():
+    from steelclaw.gateway.connectors.slack import SlackConnector
+    from steelclaw.schemas.messages import InboundMessage
+
+    received: list[InboundMessage] = []
+
+    async def handler(msg: InboundMessage) -> None:
+        received.append(msg)
+
+    config = ConnectorConfig(enabled=True, token="xoxb-test")
+    connector = SlackConnector(config=config, handler=handler)
+
+    payload = {
+        "type": "slash_commands",
+        "command": "/help",
+        "text": "",
+        "channel_id": "C123",
+        "user_id": "U456",
+        "user_name": "alice",
+        "trigger_id": "trigger-789",
+    }
+
+    await connector._handle_slash_command(payload)
+
+    assert len(received) == 1
+    msg = received[0]
+    assert msg.platform == "slack"
+    assert msg.content == "/help"
+    assert msg.platform_chat_id == "C123"
+    assert msg.platform_user_id == "U456"
+
+
+@pytest.mark.asyncio
+async def test_slack_handle_slash_command_includes_args():
+    from steelclaw.gateway.connectors.slack import SlackConnector
+    from steelclaw.schemas.messages import InboundMessage
+
+    received: list[InboundMessage] = []
+
+    async def handler(msg: InboundMessage) -> None:
+        received.append(msg)
+
+    config = ConnectorConfig(enabled=True, token="xoxb-test")
+    connector = SlackConnector(config=config, handler=handler)
+
+    payload = {
+        "type": "slash_commands",
+        "command": "/run",
+        "text": "echo hello",
+        "channel_id": "C999",
+        "user_id": "U111",
+        "user_name": "bob",
+        "trigger_id": "trigger-000",
+    }
+
+    await connector._handle_slash_command(payload)
+
+    assert received[0].content == "/run echo hello"
+
+
+# ── BaseConnector.start() calls register_commands ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_base_connector_start_calls_register_commands():
+    from steelclaw.gateway.base import BaseConnector
+    from steelclaw.schemas.messages import OutboundMessage
+
+    class DummyConnector(BaseConnector):
+        platform_name = "dummy"
+        register_commands_called = False
+
+        async def register_commands(self) -> None:
+            self.register_commands_called = True
+
+        async def _run(self) -> None:
+            pass  # no-op loop
+
+        async def send(self, message: OutboundMessage) -> None:
+            pass
+
+    config = ConnectorConfig(enabled=True, token="tok")
+    connector = DummyConnector(config=config, handler=AsyncMock())
+
+    await connector.start()
+    assert connector.register_commands_called
+    await connector.stop()


### PR DESCRIPTION
- New SteelClaw ASCII art (figlet dollar-sign font) in banner.py
- Box-drawing frame (╔═╗ style) wraps the logo and tagline
- Remove typewriter animation, _animate_typewriter, _use_animation
- Remove --static-logo CLI flag (no longer needed)
- Fix voice API: drop unsupported prefix_padding_ms from semantic_vad
- Update tests to reflect static-only banner

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>