### PR TITLE
fix: slash commands now execute real actions and Discord no longer er…

### DIFF
--- a/steelclaw/gateway/command_handler.py
+++ b/steelclaw/gateway/command_handler.py
@@ -1,0 +1,270 @@
+"""Slash command dispatcher — handles bot commands directly without routing to the LLM.
+
+Commands that are handled here return a formatted string immediately.
+Commands that return ``None`` fall through to the normal agent/LLM pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from steelclaw.gateway.commands import SLASH_COMMANDS
+
+logger = logging.getLogger("steelclaw.gateway.command_handler")
+
+# ── Help text ────────────────────────────────────────────────────────────────
+
+_HELP_HEADER = "**SteelClaw Commands**\n"
+_HELP_FOOTER = "\nSend any other message to chat with the AI assistant."
+
+# Commands visible to messenger-platform users
+_MESSENGER_COMMANDS: list[tuple[str, str]] = [
+    ("/help",    "Show this command list"),
+    ("/status",  "Show current session and bot status"),
+    ("/run",     "Execute a task  — e.g. `/run summarise the news`"),
+    ("/stop",    "End the current session"),
+    ("/memory",  "Memory actions: `status` · `clear`"),
+    ("/config",  "Show active configuration"),
+    ("/history", "Show recent conversation history (last 10 messages)"),
+    ("/new",     "Start a fresh conversation"),
+]
+
+
+def _help_text() -> str:
+    lines = [_HELP_HEADER]
+    for cmd, desc in _MESSENGER_COMMANDS:
+        lines.append(f"• `{cmd}` — {desc}")
+    lines.append(_HELP_FOOTER)
+    return "\n".join(lines)
+
+
+# ── Main dispatcher ──────────────────────────────────────────────────────────
+
+
+async def dispatch_command(
+    content: str,
+    *,
+    session=None,
+    db=None,
+    settings=None,
+) -> str | None:
+    """Attempt to handle *content* as a slash command.
+
+    Returns a response string if the command is handled here, or ``None``
+    if the message should fall through to the normal LLM agent pipeline.
+    Unrecognised ``/`` commands also return ``None`` so the agent can
+    respond naturally (e.g. "I don't know that command, but…").
+    """
+    stripped = content.strip()
+    if not stripped.startswith("/"):
+        return None
+
+    parts = stripped.split(maxsplit=1)
+    cmd = parts[0].lower()
+    args = parts[1].strip() if len(parts) > 1 else ""
+
+    if cmd in ("/help", "/start"):
+        return _help_text()
+
+    if cmd == "/status":
+        return _build_status(session)
+
+    if cmd in ("/stop", "/quit", "/exit"):
+        return await _handle_stop(session, db)
+
+    if cmd == "/memory":
+        return await _handle_memory(args, session, db)
+
+    if cmd == "/config":
+        return _handle_config(settings)
+
+    if cmd == "/history":
+        return await _handle_history(session, db)
+
+    if cmd == "/new":
+        return await _handle_new(session, db)
+
+    # /run — forward to the LLM as a task instruction
+    if cmd == "/run":
+        return None
+
+    # Any other /command — let the LLM handle it naturally
+    return None
+
+
+# ── Command implementations ──────────────────────────────────────────────────
+
+
+def _build_status(session) -> str:
+    lines = ["**SteelClaw Status**", "✓ Online"]
+    if session is not None:
+        lines.append(f"\nSession ID: `{session.id[:8]}…`")
+        lines.append(f"Platform:   {session.platform}")
+        lines.append(f"Status:     {session.status}")
+        if hasattr(session, "last_activity_at") and session.last_activity_at:
+            try:
+                last = session.last_activity_at
+                if last.tzinfo is None:
+                    last = last.replace(tzinfo=timezone.utc)
+                ago = datetime.now(timezone.utc) - last
+                total_secs = int(ago.total_seconds())
+                mins, secs = divmod(total_secs, 60)
+                hours, mins = divmod(mins, 60)
+                if hours:
+                    age = f"{hours}h {mins}m ago"
+                elif mins:
+                    age = f"{mins}m {secs}s ago"
+                else:
+                    age = f"{secs}s ago"
+                lines.append(f"Last active: {age}")
+            except Exception:
+                pass
+    return "\n".join(lines)
+
+
+async def _handle_stop(session, db) -> str:
+    if session is not None and db is not None:
+        try:
+            session.status = "closed"
+            if hasattr(session, "updated_at"):
+                session.updated_at = datetime.now(timezone.utc)
+            await db.commit()
+            return (
+                "Session ended. ✓\n"
+                "Send any message to start a new conversation."
+            )
+        except Exception as exc:
+            logger.warning("Failed to close session %s: %s", getattr(session, "id", "?"), exc)
+    return "Goodbye! Send a message to start a new session."
+
+
+async def _handle_memory(args: str, session, db) -> str:
+    action = args.lower().strip() if args else "status"
+
+    if action == "status":
+        return await _memory_status(session, db)
+
+    if action == "clear":
+        return await _memory_clear(session, db)
+
+    if action.startswith("search "):
+        query = args[len("search "):].strip()
+        return f"Memory search is not available via chat commands yet. Query: `{query}`"
+
+    return (
+        f"Unknown memory action: `{args}`.\n"
+        "Available: `/memory status` · `/memory clear`"
+    )
+
+
+async def _memory_status(session, db) -> str:
+    if session is None or db is None:
+        return "Memory: no active session."
+    try:
+        from sqlalchemy import func, select
+        from steelclaw.db.models import Message as DBMessage
+
+        result = await db.execute(
+            select(func.count(DBMessage.id)).where(
+                DBMessage.session_id == session.id
+            )
+        )
+        count = result.scalar() or 0
+        user_result = await db.execute(
+            select(func.count(DBMessage.id)).where(
+                DBMessage.session_id == session.id,
+                DBMessage.role == "user",
+            )
+        )
+        user_count = user_result.scalar() or 0
+        return (
+            f"**Memory Status**\n"
+            f"Session messages: {count} total ({user_count} from you)\n"
+            f"Use `/memory clear` to reset conversation history."
+        )
+    except Exception as exc:
+        logger.warning("Memory status query failed: %s", exc)
+        return "Memory status unavailable."
+
+
+async def _memory_clear(session, db) -> str:
+    if session is None or db is None:
+        return "No active session to clear."
+    try:
+        from sqlalchemy import delete
+        from steelclaw.db.models import Message as DBMessage
+
+        await db.execute(
+            delete(DBMessage).where(DBMessage.session_id == session.id)
+        )
+        await db.commit()
+        return (
+            "Conversation history cleared. ✓\n"
+            "The assistant no longer has context from previous messages."
+        )
+    except Exception as exc:
+        logger.warning("Memory clear failed for session %s: %s", getattr(session, "id", "?"), exc)
+        return f"Failed to clear memory: {exc}"
+
+
+async def _handle_history(session, db) -> str:
+    if session is None or db is None:
+        return "No conversation history available."
+    try:
+        from sqlalchemy import select
+        from steelclaw.db.models import Message as DBMessage
+
+        result = await db.execute(
+            select(DBMessage)
+            .where(DBMessage.session_id == session.id)
+            .order_by(DBMessage.id.desc())
+            .limit(10)
+        )
+        msgs = list(reversed(result.scalars().all()))
+        if not msgs:
+            return "No messages in current session yet."
+        lines = ["**Last 10 Messages**"]
+        for m in msgs:
+            role = "You" if m.role == "user" else "SteelClaw"
+            preview = (m.content or "")[:120].replace("\n", " ")
+            if len(m.content or "") > 120:
+                preview += "…"
+            lines.append(f"**{role}:** {preview}")
+        return "\n".join(lines)
+    except Exception as exc:
+        logger.warning("History query failed: %s", exc)
+        return "Could not retrieve history."
+
+
+async def _handle_new(session, db) -> str:
+    """Mark the current session as closed so the next message opens a fresh one."""
+    if session is not None and db is not None:
+        try:
+            session.status = "closed"
+            if hasattr(session, "updated_at"):
+                session.updated_at = datetime.now(timezone.utc)
+            await db.commit()
+        except Exception as exc:
+            logger.warning("Could not close session for /new: %s", exc)
+    return (
+        "Fresh conversation started. ✓\n"
+        "Send your next message to begin with a clean context."
+    )
+
+
+def _handle_config(settings) -> str:
+    lines = ["**Active Configuration**"]
+    if settings is None:
+        lines.append("(settings not available)")
+        return "\n".join(lines)
+    try:
+        if hasattr(settings, "mention_keywords") and settings.mention_keywords:
+            lines.append(f"Mention keywords: {', '.join(settings.mention_keywords)}")
+        if hasattr(settings, "dm_allowlist_enabled"):
+            lines.append(f"DM allowlist: {settings.dm_allowlist_enabled}")
+    except Exception:
+        pass
+    if len(lines) == 1:
+        lines.append("Configuration loaded (no public fields to display).")
+    return "\n".join(lines)

--- a/steelclaw/gateway/connectors/discord.py
+++ b/steelclaw/gateway/connectors/discord.py
@@ -1,4 +1,9 @@
-"""Discord connector — uses discord.py's async gateway."""
+"""Discord connector — uses discord.py's async gateway.
+
+Slash command interactions (Application Commands) are handled via the
+``on_interaction`` event and responded to through ``interaction.followup``
+so that Discord never shows "The application did not respond".
+"""
 
 from __future__ import annotations
 
@@ -15,6 +20,8 @@ from steelclaw.schemas.messages import InboundMessage, OutboundMessage
 logger = logging.getLogger("steelclaw.gateway.discord")
 
 _DISCORD_API = "https://discord.com/api/v10"
+# Discord's hard limit for message / followup content
+_DISCORD_MAX_LEN = 2000
 
 
 class DiscordConnector(BaseConnector):
@@ -23,12 +30,14 @@ class DiscordConnector(BaseConnector):
     def __init__(self, config, handler) -> None:
         super().__init__(config, handler)
         self._client = None
+        # interaction_id → discord.Interaction, kept while a response is in-flight
+        self._pending_interactions: dict[str, object] = {}
 
     async def register_commands(self) -> None:
         """Register global slash commands with Discord via the Application Commands REST API.
 
-        Fetches the application ID from the ``/users/@me`` endpoint then calls
-        ``/applications/{id}/commands`` to bulk-overwrite the global command list.
+        Fetches the application ID from ``/users/@me`` then bulk-overwrites
+        the global command list so users see the ``/`` autocomplete menu.
         """
         token = self.config.token
         if not token:
@@ -42,7 +51,9 @@ class DiscordConnector(BaseConnector):
                 me_resp.raise_for_status()
                 application_id = me_resp.json().get("id")
                 if not application_id:
-                    logger.warning("Discord: could not resolve application ID, skipping command registration")
+                    logger.warning(
+                        "Discord: could not resolve application ID, skipping command registration"
+                    )
                     return
 
                 # Build command payload (CHAT_INPUT = type 1)
@@ -83,6 +94,8 @@ class DiscordConnector(BaseConnector):
         client = discord.Client(intents=intents)
         self._client = client
 
+        # ── Regular text messages ────────────────────────────────────────
+
         @client.event
         async def on_message(message: discord.Message) -> None:
             if message.author == client.user:
@@ -118,10 +131,92 @@ class DiscordConnector(BaseConnector):
             )
             await self.dispatch(inbound)
 
+        # ── Slash command interactions ────────────────────────────────────
+
+        @client.event
+        async def on_interaction(interaction: discord.Interaction) -> None:
+            """Handle Application Command (slash command) interactions.
+
+            Discord requires an acknowledgment within **3 seconds** or it
+            shows "The application did not respond."  We defer immediately,
+            then process the command through the normal pipeline and send the
+            result as a followup message.
+            """
+            if interaction.type != discord.InteractionType.application_command:
+                return
+
+            # Acknowledge immediately — this MUST happen within 3 seconds.
+            try:
+                await interaction.response.defer()
+            except Exception:
+                logger.warning(
+                    "Discord: failed to defer interaction %s", interaction.id
+                )
+                return
+
+            # Build the slash command content string from interaction data
+            command_name = "/" + (interaction.data or {}).get("name", "")
+            options = (interaction.data or {}).get("options", []) or []
+            args = " ".join(
+                str(o["value"])
+                for o in options
+                if o.get("value") is not None
+            )
+            content = f"{command_name} {args}".strip()
+
+            channel_id = (
+                str(interaction.channel_id)
+                if interaction.channel_id
+                else str(interaction.user.id)
+            )
+            user = interaction.user
+
+            logger.info(
+                "Discord: slash command interaction — command=%s user=%s channel=%s",
+                command_name,
+                user,
+                channel_id,
+            )
+
+            # Store the interaction so send() can route the reply via followup
+            interaction_id = str(interaction.id)
+            self._pending_interactions[interaction_id] = interaction
+
+            inbound = InboundMessage(
+                platform="discord",
+                platform_chat_id=channel_id,
+                platform_user_id=str(user.id),
+                platform_message_id=interaction_id,
+                platform_username=str(user),
+                content=content,
+                is_group=interaction.guild is not None,
+                is_mention=False,
+            )
+
+            try:
+                await self.dispatch(inbound)
+            except Exception:
+                logger.exception(
+                    "Discord: error processing slash command interaction %s", interaction_id
+                )
+                # Clean up and send an error followup if the normal send() never ran
+                pending = self._pending_interactions.pop(interaction_id, None)
+                if pending is not None:
+                    try:
+                        await interaction.followup.send(
+                            "An error occurred while processing your command. Please try again."
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Discord: could not send error followup for %s", interaction_id
+                        )
+
         try:
             await client.start(token)
         except asyncio.CancelledError:
             await client.close()
+
+    # ── Typing indicator ──────────────────────────────────────────────────────
 
     async def send_typing(self, chat_id: str) -> None:
         if self._client is None:
@@ -140,23 +235,58 @@ class DiscordConnector(BaseConnector):
             except Exception:
                 logger.debug("Failed to send typing indicator to %s", chat_id)
 
+    # ── Send ──────────────────────────────────────────────────────────────────
+
     async def send(self, message: OutboundMessage) -> None:
+        """Send an outbound message.
+
+        If the outbound message is a reply to a slash command interaction
+        (identified by ``reply_to_message_id`` matching a pending interaction
+        ID), the response is sent via ``interaction.followup.send()`` instead
+        of the normal channel ``send()``.  This is required for Discord slash
+        commands to work correctly.
+        """
+        # Route through interaction followup when applicable
+        if message.reply_to_message_id:
+            interaction = self._pending_interactions.pop(
+                message.reply_to_message_id, None
+            )
+            if interaction is not None:
+                content = _truncate(message.content)
+                try:
+                    await interaction.followup.send(content)
+                except Exception:
+                    logger.exception(
+                        "Discord: followup.send failed for interaction %s",
+                        message.reply_to_message_id,
+                    )
+                return
+
+        # Regular channel message (not a slash command interaction)
         if self._client is None:
             return
         channel_id = int(message.platform_chat_id)
         channel = self._client.get_channel(channel_id)
         if channel is None:
-            # DM channels are often not in the cache — fetch from API
             try:
                 channel = await self._client.fetch_channel(channel_id)
             except Exception:
                 logger.warning("Discord: could not resolve channel %s", channel_id)
                 return
         if hasattr(channel, "send"):
-            await channel.send(message.content)
+            await channel.send(_truncate(message.content))
 
 
-# ── Attachment helpers ───────────────────────────────────────────────────────
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _truncate(text: str) -> str:
+    """Truncate text to Discord's 2 000-character message limit."""
+    if len(text) <= _DISCORD_MAX_LEN:
+        return text
+    suffix = "\n…*(truncated)*"
+    return text[: _DISCORD_MAX_LEN - len(suffix)] + suffix
+
 
 async def _collect_discord_attachments(discord_attachments) -> list[dict]:
     """Download Discord attachment objects and return normalised attachment dicts."""

--- a/steelclaw/gateway/router.py
+++ b/steelclaw/gateway/router.py
@@ -97,6 +97,35 @@ async def process_message(
     db.add(db_msg)
     await db.commit()
 
+    # ── Slash command interception ──────────────────────────────────────
+    # Check before routing to the LLM so commands execute instantly and
+    # deterministically (no token spend, no hallucinated responses).
+    if inbound.content.strip().startswith("/"):
+        from steelclaw.gateway.command_handler import dispatch_command
+
+        cmd_response = await dispatch_command(
+            inbound.content,
+            session=session,
+            db=db,
+            settings=settings,
+        )
+        if cmd_response is not None:
+            outbound = OutboundMessage(
+                platform=inbound.platform,
+                platform_chat_id=inbound.platform_chat_id,
+                content=cmd_response,
+                reply_to_message_id=inbound.platform_message_id,
+            )
+            db_reply = DBMessage(
+                session_id=session.id,
+                role="assistant",
+                content=outbound.content,
+                platform=outbound.platform,
+            )
+            db.add(db_reply)
+            await db.commit()
+            return outbound
+
     # Route to agent (pass db so the agent can load conversation history)
     if _agent_router is not None:
         agent_result = await _agent_router.route_with_usage(inbound, session, db=db)
@@ -188,6 +217,28 @@ async def process_message_streaming(
     )
     db.add(db_msg)
     await db.commit()
+
+    # ── Slash command interception (streaming path) ─────────────────────
+    if inbound.content.strip().startswith("/"):
+        from steelclaw.gateway.command_handler import dispatch_command
+
+        cmd_response = await dispatch_command(
+            inbound.content,
+            session=session,
+            db=db,
+            settings=settings,
+        )
+        if cmd_response is not None:
+            db_reply = DBMessage(
+                session_id=session.id,
+                role="assistant",
+                content=cmd_response,
+                platform=inbound.platform,
+            )
+            db.add(db_reply)
+            await db.commit()
+            yield {"type": "done", "content": cmd_response, "usage": {}}
+            return
 
     if _agent_router is None:
         yield {"type": "chunk", "content": f"[echo] {inbound.content}"}

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -1,8 +1,7 @@
-"""Tests for slash command registration and handling across connectors."""
+"""Tests for slash command registration, dispatch, and Discord interaction handling."""
 
 from __future__ import annotations
 
-import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -36,6 +35,144 @@ def test_slash_commands_names_have_no_slash_prefix():
         assert not cmd["name"].startswith("/"), (
             f"Command name '{cmd['name']}' must not include a leading slash"
         )
+
+
+# ── command_handler: basic dispatch ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_help_returns_text():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("/help")
+    assert result is not None
+    assert "/help" in result
+    assert "/status" in result
+
+
+@pytest.mark.asyncio
+async def test_start_is_alias_for_help():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("/start")
+    assert result is not None
+    assert "/help" in result or "Commands" in result
+
+
+@pytest.mark.asyncio
+async def test_status_without_session():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("/status")
+    assert result is not None
+    assert "Online" in result or "Status" in result
+
+
+@pytest.mark.asyncio
+async def test_status_with_session():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    session = MagicMock()
+    session.id = "abc123def456"
+    session.platform = "telegram"
+    session.status = "active"
+    session.last_activity_at = None
+
+    result = await dispatch_command("/status", session=session)
+    assert result is not None
+    assert "telegram" in result
+    assert "abc123" in result  # truncated session ID
+
+
+@pytest.mark.asyncio
+async def test_run_falls_through_to_llm():
+    """'/run <task>' should return None so the LLM handles it."""
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("/run write a poem about Python")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_falls_through():
+    """Unrecognised commands pass through so the LLM can respond naturally."""
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("/unknownxyz")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_non_slash_message_falls_through():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("Hello, how are you?")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_stop_without_session():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("/stop")
+    assert result is not None
+    assert "session" in result.lower() or "goodbye" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_stop_closes_session():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    session = MagicMock()
+    session.id = "sess-001"
+    session.status = "active"
+    db = AsyncMock()
+
+    result = await dispatch_command("/stop", session=session, db=db)
+    assert result is not None
+    assert session.status == "closed"
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_memory_status_without_session():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("/memory status")
+    assert result is not None
+    assert "session" in result.lower() or "memory" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_memory_unknown_action():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("/memory invalid_action")
+    assert result is not None
+    assert "Unknown" in result or "invalid" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_config_without_settings():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    result = await dispatch_command("/config")
+    assert result is not None
+    assert "config" in result.lower() or "Configuration" in result
+
+
+@pytest.mark.asyncio
+async def test_new_session_closes_current():
+    from steelclaw.gateway.command_handler import dispatch_command
+
+    session = MagicMock()
+    session.id = "sess-002"
+    session.status = "active"
+    db = AsyncMock()
+
+    result = await dispatch_command("/new", session=session, db=db)
+    assert result is not None
+    assert session.status == "closed"
 
 
 # ── Telegram register_commands ───────────────────────────────────────────────
@@ -76,7 +213,6 @@ async def test_telegram_register_commands_no_token():
 
     with patch("httpx.AsyncClient") as mock_client_cls:
         await connector.register_commands()
-        # Should return early without making any HTTP calls
         mock_client_cls.assert_not_called()
 
 
@@ -127,12 +263,10 @@ async def test_discord_register_commands_calls_application_commands_api():
 
         await connector.register_commands()
 
-        # Should have fetched bot identity
         mock_client.get.assert_called_once()
         get_url = mock_client.get.call_args[0][0]
         assert "/users/@me" in get_url
 
-        # Should have registered commands
         mock_client.put.assert_called_once()
         put_url = mock_client.put.call_args[0][0]
         assert "123456789" in put_url
@@ -176,8 +310,90 @@ async def test_discord_register_commands_missing_application_id_skips(caplog):
         with caplog.at_level(logging.WARNING, logger="steelclaw.gateway.discord"):
             await connector.register_commands()
 
-        # put() should NOT be called when application_id is absent
         mock_client.put.assert_not_called()
+
+
+# ── Discord: interaction-based slash command routing ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_discord_send_uses_interaction_followup_when_pending():
+    """send() routes reply through interaction.followup when a pending interaction exists."""
+    from steelclaw.gateway.connectors.discord import DiscordConnector
+    from steelclaw.schemas.messages import OutboundMessage
+
+    config = ConnectorConfig(enabled=True, token="test-token")
+    connector = DiscordConnector(config=config, handler=AsyncMock())
+
+    mock_interaction = MagicMock()
+    mock_interaction.followup = AsyncMock()
+    connector._pending_interactions["interaction-42"] = mock_interaction
+
+    message = OutboundMessage(
+        platform="discord",
+        platform_chat_id="999",
+        content="Hello from command handler",
+        reply_to_message_id="interaction-42",
+    )
+
+    await connector.send(message)
+
+    mock_interaction.followup.send.assert_awaited_once_with("Hello from command handler")
+    # Interaction should be consumed (popped)
+    assert "interaction-42" not in connector._pending_interactions
+
+
+@pytest.mark.asyncio
+async def test_discord_send_truncates_long_content():
+    """send() truncates content to Discord's 2000-char limit."""
+    from steelclaw.gateway.connectors.discord import DiscordConnector, _DISCORD_MAX_LEN
+    from steelclaw.schemas.messages import OutboundMessage
+
+    config = ConnectorConfig(enabled=True, token="test-token")
+    connector = DiscordConnector(config=config, handler=AsyncMock())
+
+    mock_interaction = MagicMock()
+    mock_interaction.followup = AsyncMock()
+    connector._pending_interactions["interaction-long"] = mock_interaction
+
+    long_content = "x" * 3000
+    message = OutboundMessage(
+        platform="discord",
+        platform_chat_id="111",
+        content=long_content,
+        reply_to_message_id="interaction-long",
+    )
+
+    await connector.send(message)
+
+    sent_text = mock_interaction.followup.send.call_args[0][0]
+    assert len(sent_text) <= _DISCORD_MAX_LEN
+
+
+@pytest.mark.asyncio
+async def test_discord_send_falls_back_to_channel_without_pending_interaction():
+    """send() uses the channel when no pending interaction exists."""
+    from steelclaw.gateway.connectors.discord import DiscordConnector
+    from steelclaw.schemas.messages import OutboundMessage
+
+    config = ConnectorConfig(enabled=True, token="test-token")
+    connector = DiscordConnector(config=config, handler=AsyncMock())
+
+    mock_channel = AsyncMock()
+    mock_client = MagicMock()
+    mock_client.get_channel.return_value = mock_channel
+    connector._client = mock_client
+
+    message = OutboundMessage(
+        platform="discord",
+        platform_chat_id="777",
+        content="regular reply",
+        reply_to_message_id="some-message-id",  # not in pending_interactions
+    )
+
+    await connector.send(message)
+
+    mock_channel.send.assert_awaited_once()
 
 
 # ── Slack register_commands ──────────────────────────────────────────────────
@@ -292,3 +508,118 @@ async def test_base_connector_start_calls_register_commands():
     await connector.start()
     assert connector.register_commands_called
     await connector.stop()
+
+
+# ── Gateway router: slash command interception ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_intercepts_help_command():
+    """process_message() returns /help response without calling the LLM agent."""
+    from steelclaw.gateway import router as gw_router
+    from steelclaw.schemas.messages import InboundMessage
+
+    inbound = InboundMessage(
+        platform="telegram",
+        platform_chat_id="chat-1",
+        platform_user_id="user-1",
+        platform_message_id="msg-1",
+        content="/help",
+    )
+
+    # Minimal mock objects
+    mock_session = MagicMock()
+    mock_session.id = "sess-router-1"
+    mock_session.unified_session_id = None
+    mock_session.status = "active"
+
+    mock_sm = AsyncMock()
+    mock_sm.resolve.return_value = mock_session
+
+    mock_db = AsyncMock()
+    mock_db.add = MagicMock()
+    mock_db.commit = AsyncMock()
+
+    mock_settings = MagicMock()
+
+    # Patch session manager and agent router
+    original_sm = gw_router._session_manager
+    original_agent = gw_router._agent_router
+    try:
+        gw_router._session_manager = mock_sm
+        gw_router._agent_router = MagicMock()  # should NOT be called
+
+        outbound = await gw_router.process_message(inbound, mock_settings, mock_db)
+
+        assert outbound is not None
+        assert "/help" in outbound.content or "Commands" in outbound.content
+        # LLM agent should not have been invoked
+        gw_router._agent_router.route_with_usage.assert_not_called()
+    finally:
+        gw_router._session_manager = original_sm
+        gw_router._agent_router = original_agent
+
+
+@pytest.mark.asyncio
+async def test_router_passes_run_command_to_llm():
+    """/run falls through to the LLM since dispatch_command returns None."""
+    from steelclaw.gateway import router as gw_router
+    from steelclaw.schemas.messages import InboundMessage, OutboundMessage
+
+    inbound = InboundMessage(
+        platform="telegram",
+        platform_chat_id="chat-2",
+        platform_user_id="user-2",
+        platform_message_id="msg-2",
+        content="/run write a haiku",
+    )
+
+    mock_session = MagicMock()
+    mock_session.id = "sess-router-2"
+    mock_session.unified_session_id = None
+    mock_session.status = "active"
+
+    mock_sm = AsyncMock()
+    mock_sm.resolve.return_value = mock_session
+
+    mock_db = AsyncMock()
+    mock_db.add = MagicMock()
+    mock_db.commit = AsyncMock()
+
+    mock_settings = MagicMock()
+
+    expected_outbound = OutboundMessage(
+        platform="telegram",
+        platform_chat_id="chat-2",
+        content="Here is your haiku…",
+        reply_to_message_id="msg-2",
+    )
+
+    mock_agent_result = MagicMock()
+    mock_agent_result.outbound = expected_outbound
+    mock_agent_result.model = "gpt-4o-mini"
+    mock_agent_result.token_usage_prompt = 10
+    mock_agent_result.token_usage_completion = 20
+    mock_agent_result.cost_usd = 0.001
+
+    mock_agent = AsyncMock()
+    mock_agent.route_with_usage.return_value = mock_agent_result
+
+    original_sm = gw_router._session_manager
+    original_agent = gw_router._agent_router
+    original_ingestor = gw_router._memory_ingestor
+    try:
+        gw_router._session_manager = mock_sm
+        gw_router._agent_router = mock_agent
+        gw_router._memory_ingestor = None
+
+        outbound = await gw_router.process_message(inbound, mock_settings, mock_db)
+
+        # LLM agent must have been called
+        mock_agent.route_with_usage.assert_awaited_once()
+        assert outbound is not None
+        assert outbound.content == "Here is your haiku…"
+    finally:
+        gw_router._session_manager = original_sm
+        gw_router._agent_router = original_agent
+        gw_router._memory_ingestor = original_ingestor


### PR DESCRIPTION
…rors

Fixes "The application did not respond" in Discord and makes all slash commands (/help, /status, /stop, /memory, /config, /new, /history) perform actual operations instead of being forwarded to the LLM.

## Root causes fixed

**Discord "app didn't respond"**
Discord Application Command interactions require an acknowledgment within 3 seconds via `interaction.response.defer()`. The previous code only had an `on_message` handler — slash command events (InteractionType. application_command) were never handled, causing Discord's timeout error.

**Commands answered like normal messages**
Slash commands were forwarded as plain text to the LLM agent, which responded conversationally instead of executing the command.

## Changes

steelclaw/gateway/command_handler.py (new)
  Central slash command dispatcher. Each command is handled directly
  without an LLM call: /help returns a formatted command list, /status
  shows live session data, /stop closes the session in the DB, /memory
  queries or clears conversation history, /config shows gateway config,
  /new and /history manage session context. /run falls through to the
  LLM so agent tasks still work. Unrecognised commands also fall through
  so the agent can respond naturally.

steelclaw/gateway/connectors/discord.py
  - Added on_interaction event handler: defers immediately (< 3 s), builds an InboundMessage from the interaction data, stores the discord.Interaction in self._pending_interactions keyed by ID, then dispatches through the normal pipeline.
  - Updated send(): when reply_to_message_id matches a pending interaction, routes the response via interaction.followup.send() (required for slash commands) instead of channel.send().
  - Added _truncate() helper to respect Discord's 2000-char limit.

steelclaw/gateway/router.py
  Both process_message() and process_message_streaming() now call
  dispatch_command() before routing to the LLM. If the command is
  handled, the response is persisted and returned immediately with no
  token spend. /run and unknown commands still reach the agent.

tests/test_slash_commands.py
  Expanded from 14 to 32 tests covering: command_handler dispatch for
  every command, Discord pending-interaction routing + truncation +
  channel fallback, and gateway router interception (help is short-
  circuited; /run still calls the agent).

https://claude.ai/code/session_012yLN9PF3yBKdAvjgW8s9E2