### PR TITLE
feat: replace typewriter animation with dollar-sign ASCII logo + box frame

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ matrix = ["matrix-nio>=0.24"]
 voice = ["openai>=1.0"]
 browser = ["playwright>=1.40"]
 memory = ["chromadb>=0.4"]
-all = ["steelclaw[telegram,discord,slack,matrix,voice,browser,memory]"]
+office = ["python-docx>=1.0", "openpyxl>=3.1", "python-pptx>=0.6"]
+all = ["steelclaw[telegram,discord,slack,matrix,voice,browser,memory,office]"]
 dev = [
     "pytest>=7",
     "pytest-asyncio>=0.21",

--- a/steelclaw/api/files.py
+++ b/steelclaw/api/files.py
@@ -22,6 +22,13 @@ DOCUMENT_TYPES = {
     "text/markdown",
     "application/json",
     "application/xml",
+    # Microsoft Office formats
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 }
 AUDIO_TYPES = {"audio/mpeg", "audio/wav", "audio/webm", "audio/ogg", "audio/mp4", "audio/flac"}
 
@@ -102,6 +109,27 @@ async def _process_file(
             text = _extract_pdf_text(content)
             preview = text[:200] + "..." if len(text) > 200 else text
             return {"text": text, "preview": preview}
+        if mime in (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/msword",
+        ) or filename.lower().endswith((".docx", ".doc")):
+            text = _extract_docx_text(content)
+            preview = text[:200] + "..." if len(text) > 200 else text
+            return {"text": text, "preview": preview}
+        if mime in (
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel",
+        ) or filename.lower().endswith((".xlsx", ".xls")):
+            text = _extract_xlsx_text(content)
+            preview = text[:200] + "..." if len(text) > 200 else text
+            return {"text": text, "preview": preview}
+        if mime in (
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "application/vnd.ms-powerpoint",
+        ) or filename.lower().endswith((".pptx", ".ppt")):
+            text = _extract_pptx_text(content)
+            preview = text[:200] + "..." if len(text) > 200 else text
+            return {"text": text, "preview": preview}
         else:
             # Text-based documents
             try:
@@ -121,6 +149,74 @@ async def _process_file(
         return {"text": text, "preview": preview}
 
     return {"preview": f"[File: {filename}]"}
+
+
+def _extract_docx_text(content: bytes) -> str:
+    """Extract text from a DOCX file using python-docx."""
+    try:
+        import io
+        import docx  # python-docx
+
+        doc = docx.Document(io.BytesIO(content))
+        parts: list[str] = []
+        for para in doc.paragraphs:
+            if para.text.strip():
+                parts.append(para.text)
+        for table in doc.tables:
+            for row in table.rows:
+                row_text = "\t".join(cell.text for cell in row.cells)
+                if row_text.strip():
+                    parts.append(row_text)
+        return "\n".join(parts) or "[DOCX contains no extractable text]"
+    except ImportError:
+        return "[DOCX reading requires python-docx — install with: pip install python-docx]"
+    except Exception as e:
+        return f"[Error reading DOCX: {e}]"
+
+
+def _extract_xlsx_text(content: bytes) -> str:
+    """Extract text from an XLSX file using openpyxl."""
+    try:
+        import io
+        import openpyxl
+
+        wb = openpyxl.load_workbook(io.BytesIO(content), read_only=True, data_only=True)
+        parts: list[str] = []
+        for sheet in wb.worksheets:
+            parts.append(f"[Sheet: {sheet.title}]")
+            for row in sheet.iter_rows(values_only=True):
+                row_text = "\t".join(str(cell) if cell is not None else "" for cell in row)
+                if row_text.strip():
+                    parts.append(row_text)
+        wb.close()
+        return "\n".join(parts) or "[XLSX contains no extractable text]"
+    except ImportError:
+        return "[XLSX reading requires openpyxl — install with: pip install openpyxl]"
+    except Exception as e:
+        return f"[Error reading XLSX: {e}]"
+
+
+def _extract_pptx_text(content: bytes) -> str:
+    """Extract text from a PPTX file using python-pptx."""
+    try:
+        import io
+        from pptx import Presentation
+
+        prs = Presentation(io.BytesIO(content))
+        parts: list[str] = []
+        for slide_num, slide in enumerate(prs.slides, start=1):
+            parts.append(f"[Slide {slide_num}]")
+            for shape in slide.shapes:
+                if shape.has_text_frame:
+                    for para in shape.text_frame.paragraphs:
+                        text = "".join(run.text for run in para.runs).strip()
+                        if text:
+                            parts.append(text)
+        return "\n".join(parts) or "[PPTX contains no extractable text]"
+    except ImportError:
+        return "[PPTX reading requires python-pptx — install with: pip install python-pptx]"
+    except Exception as e:
+        return f"[Error reading PPTX: {e}]"
 
 
 def _extract_pdf_text(content: bytes) -> str:

--- a/steelclaw/gateway/attachments.py
+++ b/steelclaw/gateway/attachments.py
@@ -60,6 +60,8 @@ _MIME_TO_CATEGORY: dict[str, str] = {
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "document",
     "application/vnd.ms-excel": "document",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "document",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "document",
+    "application/vnd.ms-powerpoint": "document",
     "text/plain": "document",
     "text/markdown": "document",
     "application/json": "document",
@@ -86,6 +88,7 @@ _EXT_TO_CATEGORY: dict[str, str] = {
     ".pdf": "document", ".doc": "document", ".docx": "document",
     ".txt": "document", ".md": "document", ".json": "document",
     ".xml": "document", ".xls": "document", ".xlsx": "document",
+    ".pptx": "document", ".ppt": "document",
 }
 
 
@@ -241,11 +244,18 @@ def _extract_csv_preview(data: bytes, filename: str) -> str | None:
 def _extract_document_text(data: bytes, filename: str) -> str | None:
     """Extract text from document bytes.
 
-    Supports PDF (via pypdf or PyPDF2 if installed), plain text, Markdown, JSON.
+    Supports PDF (via pypdf or PyPDF2 if installed), plain text, Markdown, JSON,
+    DOCX (via python-docx), XLSX (via openpyxl), and PPTX (via python-pptx).
     """
     lower = filename.lower()
     if lower.endswith(".pdf"):
         return _extract_pdf_text(data)
+    if lower.endswith((".docx", ".doc")):
+        return _extract_docx_text(data)
+    if lower.endswith((".xlsx", ".xls")):
+        return _extract_xlsx_text(data)
+    if lower.endswith((".pptx", ".ppt")):
+        return _extract_pptx_text(data)
     if lower.endswith((".txt", ".md", ".markdown")):
         return data.decode("utf-8", errors="replace")[:_MAX_TEXT_CHARS]
     if lower.endswith(".json"):
@@ -284,3 +294,74 @@ def _extract_pdf_text(data: bytes) -> str | None:
         logger.debug("PyPDF2 failed to extract text", exc_info=True)
 
     return None
+
+
+def _extract_docx_text(data: bytes) -> str | None:
+    """Extract text from a DOCX file using python-docx."""
+    try:
+        import docx  # python-docx
+
+        doc = docx.Document(io.BytesIO(data))
+        parts: list[str] = []
+        for para in doc.paragraphs:
+            if para.text.strip():
+                parts.append(para.text)
+        for table in doc.tables:
+            for row in table.rows:
+                row_text = "\t".join(cell.text for cell in row.cells)
+                if row_text.strip():
+                    parts.append(row_text)
+        return "\n".join(parts)[:_MAX_TEXT_CHARS] or "[DOCX contains no extractable text]"
+    except ImportError:
+        logger.debug("python-docx not installed; cannot extract DOCX text")
+        return "[DOCX reading requires python-docx — install with: pip install python-docx]"
+    except Exception:
+        logger.debug("Failed to extract DOCX text", exc_info=True)
+        return None
+
+
+def _extract_xlsx_text(data: bytes) -> str | None:
+    """Extract text from an XLSX file using openpyxl."""
+    try:
+        import openpyxl
+
+        wb = openpyxl.load_workbook(io.BytesIO(data), read_only=True, data_only=True)
+        parts: list[str] = []
+        for sheet in wb.worksheets:
+            parts.append(f"[Sheet: {sheet.title}]")
+            for row in sheet.iter_rows(values_only=True):
+                row_text = "\t".join(str(cell) if cell is not None else "" for cell in row)
+                if row_text.strip():
+                    parts.append(row_text)
+        wb.close()
+        return "\n".join(parts)[:_MAX_TEXT_CHARS] or "[XLSX contains no extractable text]"
+    except ImportError:
+        logger.debug("openpyxl not installed; cannot extract XLSX text")
+        return "[XLSX reading requires openpyxl — install with: pip install openpyxl]"
+    except Exception:
+        logger.debug("Failed to extract XLSX text", exc_info=True)
+        return None
+
+
+def _extract_pptx_text(data: bytes) -> str | None:
+    """Extract text from a PPTX file using python-pptx."""
+    try:
+        from pptx import Presentation
+
+        prs = Presentation(io.BytesIO(data))
+        parts: list[str] = []
+        for slide_num, slide in enumerate(prs.slides, start=1):
+            parts.append(f"[Slide {slide_num}]")
+            for shape in slide.shapes:
+                if shape.has_text_frame:
+                    for para in shape.text_frame.paragraphs:
+                        text = "".join(run.text for run in para.runs).strip()
+                        if text:
+                            parts.append(text)
+        return "\n".join(parts)[:_MAX_TEXT_CHARS] or "[PPTX contains no extractable text]"
+    except ImportError:
+        logger.debug("python-pptx not installed; cannot extract PPTX text")
+        return "[PPTX reading requires python-pptx — install with: pip install python-pptx]"
+    except Exception:
+        logger.debug("Failed to extract PPTX text", exc_info=True)
+        return None

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -835,3 +835,221 @@ async def test_file_manager_delete_file():
     result = await tool_delete_file(tmp_path)
     assert not os.path.exists(tmp_path)
     assert "Deleted" in result
+
+
+# ── Office document format support (issue #18) ───────────────────────────────
+
+
+def _make_docx_bytes(paragraphs: list[str]) -> bytes:
+    """Create a minimal in-memory DOCX with the given paragraphs."""
+    import docx
+    import io
+
+    doc = docx.Document()
+    for para in paragraphs:
+        doc.add_paragraph(para)
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _make_xlsx_bytes(sheets: dict[str, list[list]]) -> bytes:
+    """Create a minimal in-memory XLSX with the given sheets/rows."""
+    import openpyxl
+    import io
+
+    wb = openpyxl.Workbook()
+    first = True
+    for sheet_name, rows in sheets.items():
+        if first:
+            ws = wb.active
+            ws.title = sheet_name
+            first = False
+        else:
+            ws = wb.create_sheet(title=sheet_name)
+        for row in rows:
+            ws.append(row)
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def _make_pptx_bytes(slides: list[str]) -> bytes:
+    """Create a minimal in-memory PPTX with one text box per slide."""
+    from pptx import Presentation
+    from pptx.util import Inches
+    import io
+
+    prs = Presentation()
+    blank_layout = prs.slide_layouts[6]  # blank layout
+    for text in slides:
+        slide = prs.slides.add_slide(blank_layout)
+        txBox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(6), Inches(2))
+        txBox.text_frame.text = text
+    buf = io.BytesIO()
+    prs.save(buf)
+    return buf.getvalue()
+
+
+class TestOfficeMimeClassification:
+    """MIME types and extensions for Office formats resolve to 'document'."""
+
+    def test_docx_by_mime(self):
+        assert categorize_file(
+            "report.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ) == "document"
+
+    def test_docx_by_extension(self):
+        assert categorize_file("report.docx") == "document"
+
+    def test_xlsx_by_mime(self):
+        assert categorize_file(
+            "data.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ) == "document"
+
+    def test_xlsx_by_extension(self):
+        assert categorize_file("data.xlsx") == "document"
+
+    def test_pptx_by_mime(self):
+        assert categorize_file(
+            "slides.pptx",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ) == "document"
+
+    def test_pptx_by_extension(self):
+        assert categorize_file("slides.pptx") == "document"
+
+    def test_legacy_doc_extension(self):
+        assert categorize_file("old.doc") == "document"
+
+    def test_legacy_xls_extension(self):
+        assert categorize_file("old.xls") == "document"
+
+    def test_legacy_ppt_extension(self):
+        assert categorize_file("old.ppt") == "document"
+
+
+class TestDocxExtraction:
+    """Text extraction from DOCX files."""
+
+    def test_extracts_paragraph_text(self):
+        data = _make_docx_bytes(["Hello World", "Second paragraph"])
+        att = build_attachment_dict("report.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", data=data)
+        assert att["category"] == "document"
+        text = att.get("text_content", "")
+        assert "Hello World" in text
+        assert "Second paragraph" in text
+
+    def test_docx_by_extension_fallback(self):
+        """Extension-based categorisation also triggers DOCX extraction."""
+        data = _make_docx_bytes(["Extension test"])
+        att = build_attachment_dict("notes.docx", None, data=data)
+        assert att["category"] == "document"
+        assert "Extension test" in att.get("text_content", "")
+
+    def test_empty_docx_returns_placeholder(self):
+        data = _make_docx_bytes([])
+        att = build_attachment_dict("empty.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", data=data)
+        text = att.get("text_content", "")
+        # Either placeholder or empty string is acceptable
+        assert text is not None
+
+
+class TestXlsxExtraction:
+    """Text extraction from XLSX files."""
+
+    def test_extracts_cell_values(self):
+        data = _make_xlsx_bytes({"Sheet1": [["Name", "Score"], ["Alice", 95], ["Bob", 87]]})
+        att = build_attachment_dict("scores.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", data=data)
+        assert att["category"] == "document"
+        text = att.get("text_content", "")
+        assert "Alice" in text
+        assert "Sheet1" in text
+
+    def test_xlsx_sheet_name_included(self):
+        data = _make_xlsx_bytes({"Q1 Results": [["Revenue", 1000]]})
+        att = build_attachment_dict("finance.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", data=data)
+        text = att.get("text_content", "")
+        assert "Q1 Results" in text
+
+    def test_xlsx_by_extension_fallback(self):
+        data = _make_xlsx_bytes({"Data": [["x", "y"], [1, 2]]})
+        att = build_attachment_dict("data.xlsx", None, data=data)
+        assert att["category"] == "document"
+        assert "Data" in att.get("text_content", "")
+
+
+class TestPptxExtraction:
+    """Text extraction from PPTX files."""
+
+    def test_extracts_slide_text(self):
+        data = _make_pptx_bytes(["Introduction slide", "Key findings"])
+        att = build_attachment_dict("deck.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", data=data)
+        assert att["category"] == "document"
+        text = att.get("text_content", "")
+        assert "Introduction slide" in text
+        assert "Key findings" in text
+
+    def test_pptx_slide_numbers_included(self):
+        data = _make_pptx_bytes(["First", "Second"])
+        att = build_attachment_dict("deck.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", data=data)
+        text = att.get("text_content", "")
+        assert "[Slide 1]" in text
+        assert "[Slide 2]" in text
+
+    def test_pptx_by_extension_fallback(self):
+        data = _make_pptx_bytes(["Extension check"])
+        att = build_attachment_dict("slides.pptx", None, data=data)
+        assert att["category"] == "document"
+        assert "Extension check" in att.get("text_content", "")
+
+
+class TestOfficeFormatsImportMissing:
+    """Graceful degradation when Office libraries are not installed."""
+
+    def test_docx_missing_library_returns_hint(self, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "docx":
+                raise ImportError("No module named 'docx'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        from steelclaw.gateway.attachments import _extract_docx_text
+        result = _extract_docx_text(b"fake docx bytes")
+        assert result is not None
+        assert "python-docx" in result
+
+    def test_xlsx_missing_library_returns_hint(self, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "openpyxl":
+                raise ImportError("No module named 'openpyxl'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        from steelclaw.gateway.attachments import _extract_xlsx_text
+        result = _extract_xlsx_text(b"fake xlsx bytes")
+        assert result is not None
+        assert "openpyxl" in result
+
+    def test_pptx_missing_library_returns_hint(self, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "pptx":
+                raise ImportError("No module named 'pptx'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        from steelclaw.gateway.attachments import _extract_pptx_text
+        result = _extract_pptx_text(b"fake pptx bytes")
+        assert result is not None
+        assert "python-pptx" in result


### PR DESCRIPTION
- New SteelClaw ASCII art (figlet dollar-sign font) in banner.py
- Box-drawing frame (╔═╗ style) wraps the logo and tagline
- Remove typewriter animation, _animate_typewriter, _use_animation
- Remove --static-logo CLI flag (no longer needed)
- Fix voice API: drop unsupported prefix_padding_ms from semantic_vad
- Update tests to reflect static-only banner

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>