### PR TITLE
feat: add real-time tool execution feedback (issue #19)

### DIFF
--- a/steelclaw/agents/router.py
+++ b/steelclaw/agents/router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -80,10 +81,18 @@ class AgentRouter:
         message: InboundMessage,
         session: DBSession,
         db: AsyncSession | None = None,
+        on_tool_event=None,
     ) -> AgentResponse:
-        """Process a message and return response with usage metadata."""
+        """Process a message and return response with usage metadata.
+
+        ``on_tool_event`` is an optional async callable invoked with a dict
+        matching the same tool_start / tool_end schema used by the streaming
+        layer, enabling platform connectors to show real-time tool feedback.
+        """
         try:
-            response_text, usage = await self._run_agent_loop(message, session, db)
+            response_text, usage = await self._run_agent_loop(
+                message, session, db, on_tool_event=on_tool_event
+            )
         except Exception as e:
             logger.exception("Agent error for session %s", session.id)
             response_text = f"I encountered an error: {e}"
@@ -113,6 +122,7 @@ class AgentRouter:
         message: InboundMessage,
         session: DBSession,
         db: AsyncSession | None = None,
+        on_tool_event=None,
     ) -> tuple[str, dict]:
         """Run the agentic loop. Returns (response_text, accumulated_usage)."""
 
@@ -205,7 +215,33 @@ class AgentRouter:
 
             # Execute each tool call and add results
             for tc in response.tool_calls:
+                skill_obj = self._skills.get_skill_for_tool(tc.name) if self._skills else None
+                skill_name = skill_obj.name if skill_obj else None
+                skill_label = skill_obj.metadata.description if skill_obj else None
+                if on_tool_event:
+                    try:
+                        await on_tool_event({
+                            "type": "tool_start",
+                            "name": tc.name,
+                            "id": tc.id,
+                            "skill": skill_name,
+                            "label": skill_label,
+                        })
+                    except Exception:
+                        pass
+                t0 = time.monotonic()
                 result = await self._execute_tool_call(tc)
+                duration_ms = int((time.monotonic() - t0) * 1000)
+                if on_tool_event:
+                    try:
+                        await on_tool_event({
+                            "type": "tool_end",
+                            "name": tc.name,
+                            "id": tc.id,
+                            "duration_ms": duration_ms,
+                        })
+                    except Exception:
+                        pass
                 messages.append(
                     self._context.build_tool_result_message(tc.id, result)
                 )
@@ -428,15 +464,29 @@ class AgentRouter:
             )
 
             for tc in tool_calls:
-                yield {"type": "tool_start", "name": tc.name, "id": tc.id}
+                # Resolve skill name and human-readable label for this tool
+                skill_obj = self._skills.get_skill_for_tool(tc.name) if self._skills else None
+                skill_name = skill_obj.name if skill_obj else None
+                skill_label = skill_obj.metadata.description if skill_obj else None
+                yield {
+                    "type": "tool_start",
+                    "name": tc.name,
+                    "id": tc.id,
+                    "skill": skill_name,
+                    "label": skill_label,
+                }
+                t0 = time.monotonic()
                 result = await self._execute_tool_call(tc)
+                duration_ms = int((time.monotonic() - t0) * 1000)
                 messages.append(
                     self._context.build_tool_result_message(tc.id, result)
                 )
                 yield {
                     "type": "tool_end",
                     "name": tc.name,
+                    "id": tc.id,
                     "result_preview": result[:200],
+                    "duration_ms": duration_ms,
                 }
 
         # Exhausted tool rounds

--- a/steelclaw/app.py
+++ b/steelclaw/app.py
@@ -124,21 +124,42 @@ async def lifespan(app: FastAPI):
         from steelclaw.db.engine import get_async_session
 
         connector = registry.get(inbound.platform)
+        chat_id = inbound.platform_chat_id
 
         # Start typing indicator while processing
         if connector:
-            await connector.start_typing(inbound.platform_chat_id)
+            await connector.start_typing(chat_id)
+
+        async def _on_tool_event(event: dict) -> None:
+            """Forward tool_start/tool_end events to the connector as status messages."""
+            if connector is None:
+                return
+            etype = event.get("type")
+            if etype == "tool_start":
+                await connector.send_tool_status(
+                    chat_id=chat_id,
+                    tool_name=event.get("name", "tool"),
+                    call_id=event.get("id", event.get("name", "")),
+                    label=event.get("label"),
+                )
+            elif etype == "tool_end":
+                await connector.clear_tool_status(
+                    chat_id=chat_id,
+                    call_id=event.get("id", event.get("name", "")),
+                )
 
         outbound = None
         try:
             async for db in get_async_session():
-                outbound = await process_message(inbound, settings.gateway, db)
+                outbound = await process_message(
+                    inbound, settings.gateway, db, on_tool_event=_on_tool_event
+                )
         except Exception:
             logger.exception("Error processing connector message (%s)", inbound.platform)
         finally:
             # Stop typing indicator
             if connector:
-                connector.stop_typing(inbound.platform_chat_id)
+                connector.stop_typing(chat_id)
 
         if outbound and connector:
             await connector.send(outbound)

--- a/steelclaw/cli/chat.py
+++ b/steelclaw/cli/chat.py
@@ -387,8 +387,17 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
             # ── Stream response with live rendering ────────────────────
             response_text = ""
             frame_idx = 0
-            tool_active = False
             response_started = False
+            # Track active tool spinners: call_id → rich.status.Status
+            active_tool_statuses: dict[str, object] = {}
+
+            def _make_tool_status_text(tool_name: str, label: str | None, skill: str | None) -> str:
+                parts = [f"⚙ Running: [tool]{tool_name}[/tool]"]
+                if label:
+                    parts.append(f"[dim]— {label}[/dim]")
+                if skill and skill != tool_name:
+                    parts.append(f"[dim]({skill})[/dim]")
+                return "  " + " ".join(parts)
 
             with Live(
                 Text(f"  {THINKING_FRAMES[0]} Thinking...", style="dim"),
@@ -408,15 +417,20 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
 
                     if etype == "chunk":
                         response_started = True
-                        tool_active = False
                         response_text += event.get("content", "")
                         # Live-render the Markdown as it streams in
                         try:
                             rendered = Markdown(response_text)
                         except Exception:
                             rendered = Text(response_text)
+                        from rich.console import Group
+                        parts = [rendered]
+                        # Show any still-active tool indicators below content
+                        for (tn, lbl, sk) in active_tool_statuses.values():
+                            frame_idx = (frame_idx + 1) % len(TOOL_FRAMES)
+                            parts.append(Text(_make_tool_status_text(tn, lbl, sk), style="tool"))
                         live.update(Panel(
-                            rendered,
+                            Group(*parts),
                             title="[assistant] SteelClaw [/assistant]",
                             title_align="left",
                             border_style="green",
@@ -425,19 +439,26 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
                         ))
 
                     elif etype == "tool_start":
-                        tool_active = True
                         tool_name = event.get("name", "?")
+                        call_id = event.get("id") or tool_name
+                        label = event.get("label")
+                        skill = event.get("skill")
+                        active_tool_statuses[call_id] = (tool_name, label, skill)
                         frame_idx = (frame_idx + 1) % len(TOOL_FRAMES)
-                        indicator = Text()
+                        from rich.console import Group
+                        parts = []
                         if response_text:
                             try:
-                                indicator = Markdown(response_text)
+                                parts.append(Markdown(response_text))
                             except Exception:
-                                indicator = Text(response_text)
-                        status_line = Text(f"\n  {TOOL_FRAMES[frame_idx]} Using {tool_name}...", style="tool")
-                        from rich.console import Group
+                                parts.append(Text(response_text))
+                        for (tn, lbl, sk) in active_tool_statuses.values():
+                            parts.append(Text(
+                                f"\n  {TOOL_FRAMES[frame_idx]} {_make_tool_status_text(tn, lbl, sk)}",
+                                style="tool",
+                            ))
                         live.update(Panel(
-                            Group(indicator, status_line),
+                            Group(*parts) if len(parts) > 1 else (parts[0] if parts else Text("")),
                             title="[assistant] SteelClaw [/assistant]",
                             title_align="left",
                             border_style="green",
@@ -446,24 +467,36 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
                         ))
 
                     elif etype == "tool_end":
-                        tool_active = False
                         tool_name = event.get("name", "?")
+                        call_id = event.get("id") or tool_name
+                        duration_ms = event.get("duration_ms")
+                        active_tool_statuses.pop(call_id, None)
                         # Brief flash showing tool completed
+                        dur_str = f" [{duration_ms}ms]" if duration_ms is not None else ""
+                        done_line = Text(f"\n  ✓ {tool_name} done{dur_str}", style="success")
+                        from rich.console import Group
+                        parts = []
                         if response_text:
                             try:
-                                rendered = Markdown(response_text)
+                                parts.append(Markdown(response_text))
                             except Exception:
-                                rendered = Text(response_text)
-                            done_line = Text(f"\n  ✓ {tool_name} done", style="success")
-                            from rich.console import Group
-                            live.update(Panel(
-                                Group(rendered, done_line),
-                                title="[assistant] SteelClaw [/assistant]",
-                                title_align="left",
-                                border_style="green",
-                                box=box.ROUNDED,
-                                padding=(0, 1),
+                                parts.append(Text(response_text))
+                        parts.append(done_line)
+                        # Still show remaining active tools
+                        for (tn, lbl, sk) in active_tool_statuses.values():
+                            frame_idx = (frame_idx + 1) % len(TOOL_FRAMES)
+                            parts.append(Text(
+                                f"\n  {TOOL_FRAMES[frame_idx]} {_make_tool_status_text(tn, lbl, sk)}",
+                                style="tool",
                             ))
+                        live.update(Panel(
+                            Group(*parts) if len(parts) > 1 else (parts[0] if parts else Text("")),
+                            title="[assistant] SteelClaw [/assistant]",
+                            title_align="left",
+                            border_style="green",
+                            box=box.ROUNDED,
+                            padding=(0, 1),
+                        ))
 
                     elif etype == "done":
                         response_text = event.get("content", response_text)
@@ -478,8 +511,8 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
                         response_text = event.get("content", str(event))
                         break
 
-                    # Update thinking animation when no content yet
-                    if not response_started and not tool_active:
+                    # Update thinking animation when no content yet and no tools active
+                    if not response_started and not active_tool_statuses:
                         frame_idx = (frame_idx + 1) % len(THINKING_FRAMES)
                         live.update(Text(
                             f"  {THINKING_FRAMES[frame_idx]} Thinking...",

--- a/steelclaw/gateway/base.py
+++ b/steelclaw/gateway/base.py
@@ -82,6 +82,26 @@ class BaseConnector(ABC):
         """Send a one-shot typing indicator. Override in subclasses that support it."""
         pass
 
+    async def send_tool_status(
+        self, chat_id: str, tool_name: str, call_id: str, label: str | None = None
+    ) -> None:
+        """Send an ephemeral tool-execution status message.
+
+        Called when a tool starts executing. Platforms that support editable
+        or deletable messages (Telegram, Discord, Slack) should send a
+        temporary status message and store its ID for later removal.
+        Non-editable platforms can leave this as a no-op or fall back to typing.
+        """
+        pass
+
+    async def clear_tool_status(self, chat_id: str, call_id: str) -> None:
+        """Remove the ephemeral tool-execution status message, if any.
+
+        Called when a tool finishes. Should delete or update the message
+        sent by ``send_tool_status`` for the same ``call_id``.
+        """
+        pass
+
     async def start_typing(self, chat_id: str) -> None:
         """Start a persistent typing indicator that auto-refreshes.
 

--- a/steelclaw/gateway/connectors/discord.py
+++ b/steelclaw/gateway/connectors/discord.py
@@ -32,6 +32,8 @@ class DiscordConnector(BaseConnector):
         self._client = None
         # interaction_id → discord.Interaction, kept while a response is in-flight
         self._pending_interactions: dict[str, object] = {}
+        # (channel_id, call_id) → discord message object for ephemeral tool status
+        self._tool_status_msgs: dict[tuple[str, str], object] = {}
 
     async def register_commands(self) -> None:
         """Register global slash commands with Discord via the Application Commands REST API.
@@ -234,6 +236,36 @@ class DiscordConnector(BaseConnector):
                     pass
             except Exception:
                 logger.debug("Failed to send typing indicator to %s", chat_id)
+
+    async def send_tool_status(
+        self, chat_id: str, tool_name: str, call_id: str, label: str | None = None
+    ) -> None:
+        """Send an ephemeral-style tool status message to the Discord channel."""
+        if self._client is None:
+            return
+        try:
+            channel_id = int(chat_id)
+            channel = self._client.get_channel(channel_id)
+            if channel is None:
+                channel = await self._client.fetch_channel(channel_id)
+            if channel and hasattr(channel, "send"):
+                text = f"⚙ Running: **{tool_name}**"
+                if label:
+                    text += f"\n*{label}*"
+                msg = await channel.send(text)
+                self._tool_status_msgs[(chat_id, call_id)] = msg
+        except Exception:
+            logger.debug("Failed to send tool status to Discord channel %s", chat_id)
+
+    async def clear_tool_status(self, chat_id: str, call_id: str) -> None:
+        """Delete the ephemeral tool status message."""
+        msg = self._tool_status_msgs.pop((chat_id, call_id), None)
+        if msg is None:
+            return
+        try:
+            await msg.delete()
+        except Exception:
+            logger.debug("Failed to delete Discord tool status message in channel %s", chat_id)
 
     # ── Send ──────────────────────────────────────────────────────────────────
 

--- a/steelclaw/gateway/connectors/slack.py
+++ b/steelclaw/gateway/connectors/slack.py
@@ -22,6 +22,11 @@ _HANDLED_SUBTYPES = frozenset({"file_share"})
 class SlackConnector(BaseConnector):
     platform_name = "slack"
 
+    def __init__(self, config, handler) -> None:
+        super().__init__(config, handler)
+        # (channel_id, call_id) → {"ts": message_ts, "channel": channel} for deletion
+        self._tool_status_msgs: dict[tuple[str, str], dict] = {}
+
     async def register_commands(self) -> None:
         """Log the slash commands that must be configured in the Slack app manifest.
 
@@ -239,6 +244,50 @@ class SlackConnector(BaseConnector):
             is_mention=False,
         )
         await self.dispatch(inbound)
+
+    async def send_tool_status(
+        self, chat_id: str, tool_name: str, call_id: str, label: str | None = None
+    ) -> None:
+        """Post an ephemeral-style tool status message to the Slack channel."""
+        token = self.config.token
+        if not token:
+            return
+        text = f"⚙ Running: *{tool_name}*"
+        if label:
+            text += f"\n_{label}_"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(
+                    "https://slack.com/api/chat.postMessage",
+                    headers={"Authorization": f"Bearer {token}"},
+                    json={"channel": chat_id, "text": text},
+                )
+                data = resp.json()
+                if data.get("ok"):
+                    self._tool_status_msgs[(chat_id, call_id)] = {
+                        "ts": data["ts"],
+                        "channel": chat_id,
+                    }
+        except Exception:
+            logger.debug("Failed to send tool status to Slack channel %s", chat_id)
+
+    async def clear_tool_status(self, chat_id: str, call_id: str) -> None:
+        """Delete the ephemeral tool status message from Slack."""
+        info = self._tool_status_msgs.pop((chat_id, call_id), None)
+        if not info:
+            return
+        token = self.config.token
+        if not token:
+            return
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                await client.post(
+                    "https://slack.com/api/chat.delete",
+                    headers={"Authorization": f"Bearer {token}"},
+                    json={"channel": info["channel"], "ts": info["ts"]},
+                )
+        except Exception:
+            logger.debug("Failed to delete Slack tool status message in channel %s", chat_id)
 
     async def send(self, message: OutboundMessage) -> None:
         token = self.config.token

--- a/steelclaw/gateway/connectors/telegram.py
+++ b/steelclaw/gateway/connectors/telegram.py
@@ -21,6 +21,8 @@ class TelegramConnector(BaseConnector):
     def __init__(self, config, handler) -> None:
         super().__init__(config, handler)
         self._offset = 0
+        # Maps (chat_id, call_id) → telegram message_id for ephemeral tool status msgs
+        self._tool_status_msgs: dict[tuple[str, str], int] = {}
 
     async def register_commands(self) -> None:
         """Register slash commands with Telegram via setMyCommands API."""
@@ -318,6 +320,48 @@ class TelegramConnector(BaseConnector):
                 )
         except Exception:
             logger.debug("Failed to send typing indicator to %s", chat_id)
+
+    async def send_tool_status(
+        self, chat_id: str, tool_name: str, call_id: str, label: str | None = None
+    ) -> None:
+        """Send an ephemeral status message showing which tool is running."""
+        import httpx
+
+        token = self.config.token
+        if not token:
+            return
+        text = f"⚙ Running: {tool_name}"
+        if label:
+            text += f"\n_{label}_"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(
+                    f"https://api.telegram.org/bot{token}/sendMessage",
+                    json={"chat_id": chat_id, "text": text, "parse_mode": "Markdown"},
+                )
+                data = resp.json()
+                if data.get("ok"):
+                    msg_id = data["result"]["message_id"]
+                    self._tool_status_msgs[(chat_id, call_id)] = msg_id
+        except Exception:
+            logger.debug("Failed to send tool status message to %s", chat_id)
+
+    async def clear_tool_status(self, chat_id: str, call_id: str) -> None:
+        """Delete the ephemeral tool status message."""
+        import httpx
+
+        token = self.config.token
+        msg_id = self._tool_status_msgs.pop((chat_id, call_id), None)
+        if not token or msg_id is None:
+            return
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                await client.post(
+                    f"https://api.telegram.org/bot{token}/deleteMessage",
+                    json={"chat_id": chat_id, "message_id": msg_id},
+                )
+        except Exception:
+            logger.debug("Failed to delete tool status message %s in chat %s", msg_id, chat_id)
 
     async def send(self, message: OutboundMessage) -> None:
         import httpx

--- a/steelclaw/gateway/router.py
+++ b/steelclaw/gateway/router.py
@@ -62,8 +62,14 @@ async def process_message(
     inbound: InboundMessage,
     settings: GatewaySettings,
     db: AsyncSession,
+    on_tool_event=None,
 ) -> OutboundMessage | None:
-    """Full pipeline: session resolution → persist → agent → respond."""
+    """Full pipeline: session resolution → persist → agent → respond.
+
+    ``on_tool_event`` is an optional async callable that receives tool_start /
+    tool_end event dicts, allowing platform connectors to show real-time
+    tool-execution status to their users.
+    """
     sm = _get_session_manager(settings)
 
     session = await sm.resolve(inbound, db)
@@ -128,7 +134,9 @@ async def process_message(
 
     # Route to agent (pass db so the agent can load conversation history)
     if _agent_router is not None:
-        agent_result = await _agent_router.route_with_usage(inbound, session, db=db)
+        agent_result = await _agent_router.route_with_usage(
+            inbound, session, db=db, on_tool_event=on_tool_event
+        )
         outbound = agent_result.outbound
 
         # Persist outbound message with usage metadata

--- a/steelclaw/web/static/index.html
+++ b/steelclaw/web/static/index.html
@@ -213,8 +213,12 @@ body {
 .streaming-cursor { color: var(--accent); animation: blink 0.6s step-end infinite; font-weight: bold; }
 @keyframes blink { 50% { opacity: 0; } }
 .streaming-body { min-height: 1.2em; }
-.tool-indicator { color: var(--accent); font-size: 12px; padding: 6px 0 2px; display: flex; align-items: center; gap: 6px; }
-.tool-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite; }
+.tool-indicator { color: var(--accent); font-size: 12px; padding: 5px 10px; display: flex; align-items: center; gap: 8px; background: var(--glass-elevated); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid var(--glass-border); border-radius: 8px; margin: 4px 0 2px; animation: toolSlideIn 0.2s ease; }
+.tool-indicator .tool-label { color: var(--text-secondary); font-size: 11px; margin-left: 2px; }
+.tool-indicator .tool-skill { font-size: 10px; color: var(--text-dim, var(--text-secondary)); opacity: 0.7; margin-left: auto; }
+.tool-indicators-stack { display: flex; flex-direction: column; gap: 2px; }
+.tool-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite; flex-shrink: 0; }
+@keyframes toolSlideIn { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes spin { to { transform: rotate(360deg); } }
 .typing-dots { display: inline-flex; gap: 4px; align-items: center; padding: 4px 0; }
 .typing-dots span { display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); animation: bounce 1.4s infinite ease-in-out; }
@@ -916,7 +920,8 @@ let ws = null;
 // ── Streaming state ───────────────────────────────────────
 let _streamingMsgEl = null;   // The DOM element being streamed into
 let _streamingContent = '';    // Accumulated text so far
-let _streamingToolEl = null;   // Tool indicator element
+let _streamingToolEl = null;   // Tool indicators container element
+let _activeToolEls = {};       // call_id → individual tool indicator element
 
 function _createStreamingMsg() {
   removeTyping();
@@ -950,23 +955,44 @@ function _appendStreamChunk(text) {
   msgEl.scrollTop = msgEl.scrollHeight;
 }
 
-function _showToolIndicator(toolName) {
+function _showToolIndicator(toolName, callId, skillName, label) {
   if (!_streamingMsgEl) _createStreamingMsg();
-  if (_streamingToolEl) _streamingToolEl.remove();
-  const ind = document.createElement('div'); ind.className='tool-indicator';
-  ind.innerHTML = '<span class="tool-spinner"></span> Using <strong>' + (toolName||'tool') + '</strong>...';
-  _streamingMsgEl._bodyEl.appendChild(ind);
-  _streamingToolEl = ind;
+  // Create container stack once
+  if (!_streamingToolEl) {
+    _streamingToolEl = document.createElement('div');
+    _streamingToolEl.className = 'tool-indicators-stack';
+    _streamingMsgEl._bodyEl.appendChild(_streamingToolEl);
+  }
+  const ind = document.createElement('div'); ind.className = 'tool-indicator';
+  const displayName = toolName || 'tool';
+  let html = '<span class="tool-spinner"></span> <span>⚙ Running: <strong>' + displayName + '</strong></span>';
+  if (label) html += '<span class="tool-label">' + label + '</span>';
+  if (skillName && skillName !== displayName) html += '<span class="tool-skill">' + skillName + '</span>';
+  ind.innerHTML = html;
+  _streamingToolEl.appendChild(ind);
+  const key = callId || toolName || ('_t' + Date.now());
+  _activeToolEls[key] = ind;
   msgEl.scrollTop = msgEl.scrollHeight;
 }
 
-function _removeToolIndicator() {
-  if (_streamingToolEl) { _streamingToolEl.remove(); _streamingToolEl = null; }
+function _removeToolIndicator(callId, toolName) {
+  const key = callId || toolName;
+  if (key && _activeToolEls[key]) {
+    _activeToolEls[key].remove();
+    delete _activeToolEls[key];
+  }
+  // If no more active tools, remove the container
+  if (_streamingToolEl && Object.keys(_activeToolEls).length === 0) {
+    _streamingToolEl.remove();
+    _streamingToolEl = null;
+  }
 }
 
 function _finalizeStream(fullContent) {
   if (!_streamingMsgEl) _createStreamingMsg();
-  _removeToolIndicator();
+  // Remove all active tool indicators
+  if (_streamingToolEl) { _streamingToolEl.remove(); _streamingToolEl = null; }
+  _activeToolEls = {};
   const finalText = fullContent || _streamingContent;
   const body = _streamingMsgEl._bodyEl;
   body.innerHTML = renderMarkdown(finalText);
@@ -992,9 +1018,9 @@ function wsConnect() {
       _appendStreamChunk(d.content || '');
     } else if (etype === 'tool_start') {
       removeTyping();
-      _showToolIndicator(d.name || 'tool');
+      _showToolIndicator(d.name || 'tool', d.id, d.skill, d.label);
     } else if (etype === 'tool_end') {
-      _removeToolIndicator();
+      _removeToolIndicator(d.id, d.name);
     } else if (etype === 'done') {
       removeTyping();
       _finalizeStream(d.content);

--- a/tests/test_streaming_tool_loop.py
+++ b/tests/test_streaming_tool_loop.py
@@ -206,3 +206,142 @@ async def test_execute_tool_call_guards_none_result():
 
     assert isinstance(result, str)
     assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_tool_start_event_includes_skill_and_label():
+    """tool_start events must include 'skill', 'label', and 'id' fields.
+    tool_end events must include 'id' and 'duration_ms' fields.
+    """
+    settings = AgentSettings()
+    router = AgentRouter(settings)
+
+    call_count = 0
+
+    async def fake_stream(messages, tools=None, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            for chunk in _tool_chunk("web_search", "call_skill_test", '{"query":"test"}'):
+                yield chunk
+        else:
+            yield _text_chunk("Result.")
+
+    router._provider = MagicMock()
+    router._provider.stream = fake_stream
+
+    router._context = MagicMock()
+    router._context.build = AsyncMock(return_value=[
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "search"},
+    ])
+    router._context._build_user_message = lambda t, a=None: {"role": "user", "content": t}
+    from steelclaw.llm.context import ContextBuilder
+    ctx = ContextBuilder(settings.llm)
+    router._context.build_assistant_tool_call_message = ctx.build_assistant_tool_call_message
+    router._context.build_tool_result_message = ctx.build_tool_result_message
+
+    # Mock registry with a skill that has a description
+    mock_skill = MagicMock()
+    mock_skill.name = "web_search"
+    mock_skill.metadata = MagicMock()
+    mock_skill.metadata.description = "Search the web for information"
+
+    mock_registry = MagicMock()
+    mock_registry.get_combined_system_context.return_value = ""
+    mock_registry.get_all_tools_schema.return_value = []
+    mock_registry.get_skill_for_tool.return_value = mock_skill
+    mock_registry.execute_tool = AsyncMock(return_value="Search results.")
+    router._skills = mock_registry
+
+    events = []
+    async for event in router.stream_response(_make_inbound("search"), _make_session()):
+        events.append(event)
+
+    tool_start = next((e for e in events if e["type"] == "tool_start"), None)
+    tool_end = next((e for e in events if e["type"] == "tool_end"), None)
+
+    assert tool_start is not None, "Expected a tool_start event"
+    assert tool_start.get("skill") == "web_search"
+    assert tool_start.get("label") == "Search the web for information"
+    assert tool_start.get("id") == "call_skill_test"
+
+    assert tool_end is not None, "Expected a tool_end event"
+    assert tool_end.get("id") == "call_skill_test"
+    assert isinstance(tool_end.get("duration_ms"), int)
+    assert tool_end.get("duration_ms") >= 0
+
+
+@pytest.mark.asyncio
+async def test_on_tool_event_callback_called_for_non_streaming():
+    """on_tool_event callback must be invoked for tool_start/end in route_with_usage."""
+    settings = AgentSettings()
+    router = AgentRouter(settings)
+
+    async def fake_complete(messages, tools=None, **kwargs):
+        from steelclaw.llm.provider import LLMResponse
+        call_count = getattr(fake_complete, "_calls", 0) + 1
+        fake_complete._calls = call_count
+        if call_count == 1:
+            return LLMResponse(
+                content=None,
+                tool_calls=[ToolCall(id="call_cb_1", name="calc", arguments={})],
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+                model="test-model",
+                finish_reason="tool_calls",
+            )
+        return LLMResponse(
+            content="Computed.",
+            tool_calls=[],
+            usage={"prompt_tokens": 5, "completion_tokens": 3},
+            model="test-model",
+            finish_reason="stop",
+        )
+
+    router._provider = MagicMock()
+    router._provider.complete = fake_complete
+
+    router._context = MagicMock()
+    router._context.build = AsyncMock(return_value=[
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "compute"},
+    ])
+    router._context._build_user_message = lambda t, a=None: {"role": "user", "content": t}
+    from steelclaw.llm.context import ContextBuilder
+    ctx = ContextBuilder(settings.llm)
+    router._context.build_assistant_tool_call_message = ctx.build_assistant_tool_call_message
+    router._context.build_tool_result_message = ctx.build_tool_result_message
+
+    mock_skill = MagicMock()
+    mock_skill.name = "calculator"
+    mock_skill.metadata = MagicMock()
+    mock_skill.metadata.description = "Perform calculations"
+
+    mock_registry = MagicMock()
+    mock_registry.get_combined_system_context.return_value = ""
+    mock_registry.get_all_tools_schema.return_value = []
+    mock_registry.get_skill_for_tool.return_value = mock_skill
+    mock_registry.execute_tool = AsyncMock(return_value="42")
+    router._skills = mock_registry
+
+    received_events = []
+
+    async def _on_tool_event(event):
+        received_events.append(event)
+
+    inbound = _make_inbound("compute")
+    session = _make_session()
+    await router.route_with_usage(inbound, session, on_tool_event=_on_tool_event)
+
+    types = [e["type"] for e in received_events]
+    assert "tool_start" in types
+    assert "tool_end" in types
+
+    start = next(e for e in received_events if e["type"] == "tool_start")
+    assert start["name"] == "calc"
+    assert start["skill"] == "calculator"
+    assert start["label"] == "Perform calculations"
+
+    end = next(e for e in received_events if e["type"] == "tool_end")
+    assert end["name"] == "calc"
+    assert isinstance(end["duration_ms"], int)


### PR DESCRIPTION
Emit enriched tool_start/tool_end events with skill name, human-readable label, call ID, and duration metrics across all platforms.

Streaming layer (agents/router.py):
- tool_start now includes: name, id, skill (skill name), label (description)
- tool_end now includes: name, id, result_preview, duration_ms
- Non-streaming route_with_usage accepts on_tool_event callback for platform connectors

Web UI (index.html):
- Tool indicators use glassmorphism glass-elevated style with slide-in animation
- Parallel tool calls each get their own indicator stacked in a container
- Indicators show tool name, optional label, and skill name
- _removeToolIndicator(callId, name) removes individual indicators by call ID

CLI TUI (chat.py):
- Parallel tool call tracking via active_tool_statuses dict (call_id → metadata)
- Each tool_start/end shows name, label, skill, and duration
- Remaining active tools stay visible when one completes

Platform connectors (Telegram, Discord, Slack):
- BaseConnector gains send_tool_status() and clear_tool_status() (no-op defaults)
- TelegramConnector: sends a temporary message "⚙ Running: tool" and deletes it on complete
- DiscordConnector: posts and deletes a status message in the channel
- SlackConnector: posts and deletes a status message via chat.postMessage/chat.delete
- app.py _connector_handler passes an on_tool_event callback that calls send/clear_tool_status

Tests (test_streaming_tool_loop.py):
- test_tool_start_event_includes_skill_and_label: verifies new streaming event fields
- test_on_tool_event_callback_called_for_non_streaming: verifies callback in route_with_usage

https://claude.ai/code/session_01FfzuwRmfHuHrgyv7dfKifZ