### PR TITLE
feat: Agent Intelligence Upgrade — Extended Permissions, Sudo Support…

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -80,7 +80,17 @@
       "default_permission": "ask",
       "sandbox_enabled": true,
       "max_command_timeout": 30,
-      "blocked_commands": ["rm -rf /", "mkfs", "dd if=", ":(){:|:&};:"]
+      "blocked_commands": ["rm -rf /", "mkfs", "dd if=", ":(){:|:&};:"],
+      "sudo": {
+        "enabled": false,
+        "whitelist": [],
+        "audit_log": "~/.steelclaw/sudo_audit.log",
+        "session_timeout": 30
+      },
+      "extended_permissions": {
+        "permissions_file": "~/.steelclaw/permissions.yaml",
+        "auto_create_file": true
+      }
     },
     "scheduler": {
       "enabled": true,
@@ -105,6 +115,16 @@
       "openviking_auto_start": true,
       "openviking_port": 1933,
       "openviking_log_level": "info"
+    },
+    "reflection": {
+      "enabled": false,
+      "threshold": 5,
+      "skill_auto_create": false
+    },
+    "memory_fts": {
+      "enabled": false,
+      "db_path": "~/.steelclaw/memory_fts.db",
+      "nudge_limit": 3
     }
   }
 }

--- a/steelclaw/agents/router.py
+++ b/steelclaw/agents/router.py
@@ -79,6 +79,9 @@ class AgentRouter:
         self._memory_retriever = None
         self._memory_ingestor = None
         self._skill_generator = None  # Optional[SkillGenerator] — set via set_skill_generator()
+        # Tracks live background reflection tasks so they are not garbage-collected
+        # mid-execution and can be awaited during graceful shutdown.
+        self._background_tasks: set[asyncio.Task] = set()
 
         # Apply per-agent model/temperature overrides when a profile is provided
         llm_settings = settings.llm
@@ -379,7 +382,10 @@ class AgentRouter:
             except Exception as exc:
                 logger.warning("Reflection failed: %s", exc)
 
-        asyncio.create_task(_reflect())
+        task = asyncio.create_task(_reflect())
+        self._background_tasks.add(task)
+        # Remove from the tracking set once done so memory is not leaked
+        task.add_done_callback(self._background_tasks.discard)
 
     def _select_relevant_tools(
         self, message_content: str, all_tools: list[dict],

--- a/steelclaw/agents/router.py
+++ b/steelclaw/agents/router.py
@@ -288,7 +288,7 @@ class AgentRouter:
                         len(think_blocks),
                         " | ".join(b[:100] for b in think_blocks),
                     )
-                    final_text = _strip_think_blocks(final_text)
+                    final_text = _strip_think_blocks(final_text) or "(no response)"
 
                 usage = {
                     "model": model_used,

--- a/steelclaw/agents/router.py
+++ b/steelclaw/agents/router.py
@@ -28,6 +28,35 @@ logger = logging.getLogger("steelclaw.agents")
 # OpenAI and most providers cap tools at 128
 MAX_TOOLS = 128
 
+# Module-level set that tracks all live reflection background tasks across ALL
+# AgentRouter instances.  Each request creates a fresh router, so per-instance
+# tracking alone is insufficient: the router is GC'd after the response is
+# returned, which could silently cancel its tasks before they finish.
+# Using a module-level set gives app.py a single place to drain on shutdown.
+_active_background_tasks: set[asyncio.Task] = set()
+
+
+async def drain_background_tasks(timeout: float = 10.0) -> None:
+    """Await all active reflection tasks, with a graceful timeout.
+
+    Called from the app lifespan shutdown sequence so that in-progress
+    skill-file writes and ReflectionLog entries can complete cleanly.
+    """
+    pending = list(_active_background_tasks)
+    if not pending:
+        return
+    logger.info("Draining %d background reflection task(s)…", len(pending))
+    done, still_running = await asyncio.wait(pending, timeout=timeout)
+    if still_running:
+        logger.warning(
+            "%d background task(s) did not finish within %.1fs; cancelling.",
+            len(still_running), timeout,
+        )
+        for t in still_running:
+            t.cancel()
+        await asyncio.gather(*still_running, return_exceptions=True)
+
+
 # Regex to strip <think>...</think> reasoning blocks from LLM responses.
 # These are internal reasoning traces that must not appear in user-facing output.
 _THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
@@ -383,9 +412,13 @@ class AgentRouter:
                 logger.warning("Reflection failed: %s", exc)
 
         task = asyncio.create_task(_reflect())
+        # Track in both the instance set and the module-level set.
+        # The instance set provides per-router visibility; the module-level set
+        # allows app.py to drain tasks after the router instance is GC'd.
         self._background_tasks.add(task)
-        # Remove from the tracking set once done so memory is not leaked
+        _active_background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
+        task.add_done_callback(_active_background_tasks.discard)
 
     def _select_relevant_tools(
         self, message_content: str, all_tools: list[dict],

--- a/steelclaw/agents/router.py
+++ b/steelclaw/agents/router.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import re
 import time
 from collections.abc import AsyncIterator
 from copy import copy
@@ -25,6 +27,23 @@ logger = logging.getLogger("steelclaw.agents")
 
 # OpenAI and most providers cap tools at 128
 MAX_TOOLS = 128
+
+# Regex to strip <think>...</think> reasoning blocks from LLM responses.
+# These are internal reasoning traces that must not appear in user-facing output.
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+
+def _strip_think_blocks(text: str) -> str:
+    """Remove <think>...</think> blocks from *text* and return cleaned output."""
+    cleaned = _THINK_RE.sub("", text)
+    # Normalise leftover blank lines
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def _extract_think_blocks(text: str) -> list[str]:
+    """Return the content of all <think>...</think> blocks (for debug logging)."""
+    return _THINK_RE.findall(text)
 
 
 @dataclass
@@ -59,6 +78,7 @@ class AgentRouter:
         self._skills = skill_registry
         self._memory_retriever = None
         self._memory_ingestor = None
+        self._skill_generator = None  # Optional[SkillGenerator] — set via set_skill_generator()
 
         # Apply per-agent model/temperature overrides when a profile is provided
         llm_settings = settings.llm
@@ -77,6 +97,10 @@ class AgentRouter:
         """Inject memory components after initialisation."""
         self._memory_retriever = retriever
         self._memory_ingestor = ingestor
+
+    def set_skill_generator(self, generator) -> None:
+        """Inject the skill generator for autonomous skill creation."""
+        self._skill_generator = generator
 
     async def route(
         self,
@@ -204,6 +228,9 @@ class AgentRouter:
         total_completion = 0
         model_used = None
 
+        # Track tool calls for self-reflection
+        tool_calls_log: list[dict] = []
+
         # Agent loop with tool calling
         max_rounds = self._settings.max_tool_rounds
         for round_num in range(max_rounds):
@@ -217,14 +244,34 @@ class AgentRouter:
             total_prompt += response.usage.get("prompt_tokens", 0)
             total_completion += response.usage.get("completion_tokens", 0)
 
-            # If no tool calls, return the text response
+            # If no tool calls, we have the final text response
             if not response.tool_calls:
+                final_text = response.content or "(no response)"
+
+                # Strip <think>...</think> reasoning blocks before returning
+                think_blocks = _extract_think_blocks(final_text)
+                if think_blocks:
+                    logger.debug(
+                        "Stripping %d <think> block(s) from response: %s",
+                        len(think_blocks),
+                        " | ".join(b[:100] for b in think_blocks),
+                    )
+                    final_text = _strip_think_blocks(final_text)
+
                 usage = {
                     "model": model_used,
                     "prompt_tokens": total_prompt,
                     "completion_tokens": total_completion,
                 }
-                return response.content or "(no response)", usage
+
+                # Fire-and-forget reflection when threshold is met
+                self._maybe_trigger_reflection(
+                    tool_calls_log=tool_calls_log,
+                    task_context=message.content[:200] if message.content else "",
+                    session_id=session.id,
+                )
+
+                return final_text, usage
 
             # Process tool calls
             logger.info(
@@ -275,18 +322,64 @@ class AgentRouter:
                 messages.append(
                     self._context.build_tool_result_message(tc.id, result)
                 )
+                # Log for reflection
+                tool_calls_log.append({"name": tc.name, "arguments": tc.arguments})
 
-        # Exhausted tool rounds
+        # Exhausted tool rounds — still fire reflection and strip any think blocks
+        final_text = response.content or "I've been working on this but reached my iteration limit. Here's what I have so far."
+        final_text = _strip_think_blocks(final_text)
+
+        self._maybe_trigger_reflection(
+            tool_calls_log=tool_calls_log,
+            task_context=message.content[:200] if message.content else "",
+            session_id=session.id,
+        )
+
         logger.warning("Agent exhausted %d tool rounds", max_rounds)
         usage = {
             "model": model_used,
             "prompt_tokens": total_prompt,
             "completion_tokens": total_completion,
         }
-        return (
-            response.content or "I've been working on this but reached my iteration limit. Here's what I have so far.",
-            usage,
+        return final_text, usage
+
+    def _maybe_trigger_reflection(
+        self,
+        tool_calls_log: list[dict],
+        task_context: str,
+        session_id: str,
+    ) -> None:
+        """Fire-and-forget reflection when the tool-call threshold is met.
+
+        Does nothing if reflection is disabled or threshold not reached.
+        """
+        reflection_settings = self._settings.reflection
+        if not reflection_settings.enabled:
+            return
+        if len(tool_calls_log) < reflection_settings.threshold:
+            return
+        if self._skill_generator is None:
+            return
+
+        logger.info(
+            "Reflection triggered: %d tool calls >= threshold %d (session %s)",
+            len(tool_calls_log),
+            reflection_settings.threshold,
+            session_id,
         )
+
+        async def _reflect():
+            try:
+                result = await self._skill_generator.reflect_and_create(
+                    tool_calls_log=tool_calls_log,
+                    task_context=task_context,
+                    skill_auto_create=reflection_settings.skill_auto_create,
+                )
+                logger.info("Reflection result: %s", result.get("reason", ""))
+            except Exception as exc:
+                logger.warning("Reflection failed: %s", exc)
+
+        asyncio.create_task(_reflect())
 
     def _select_relevant_tools(
         self, message_content: str, all_tools: list[dict],
@@ -489,12 +582,14 @@ class AgentRouter:
 
             # No tool calls → we're done
             if not tool_calls:
+                # Strip any <think> blocks from the accumulated content
+                clean_content = _strip_think_blocks(full_content) if full_content else "(no response)"
                 usage = {
                     "model": model_used,
                     "prompt_tokens": total_prompt,
                     "completion_tokens": total_completion,
                 }
-                yield {"type": "done", "content": full_content or "(no response)", "usage": usage}
+                yield {"type": "done", "content": clean_content, "usage": usage}
                 return
 
             # Execute tool calls
@@ -536,6 +631,7 @@ class AgentRouter:
                 }
 
         # Exhausted tool rounds
+        clean_content = _strip_think_blocks(full_content) if full_content else "I've been working on this but reached my iteration limit."
         usage = {
             "model": model_used,
             "prompt_tokens": total_prompt,
@@ -543,7 +639,7 @@ class AgentRouter:
         }
         yield {
             "type": "done",
-            "content": full_content or "I've been working on this but reached my iteration limit.",
+            "content": clean_content,
             "usage": usage,
         }
 

--- a/steelclaw/app.py
+++ b/steelclaw/app.py
@@ -256,6 +256,12 @@ async def lifespan(app: FastAPI):
     # ── Shutdown ────────────────────────────────────────────────────────
     task_engine.stop()
     await registry.stop_all()
+
+    # Drain in-progress reflection background tasks before closing resources
+    # so that skill-file writes and ReflectionLog entries can complete cleanly.
+    from steelclaw.agents.router import drain_background_tasks
+    await drain_background_tasks(timeout=10.0)
+
     await dispose_engine()
 
     # Stop OpenViking server if we started it

--- a/steelclaw/app.py
+++ b/steelclaw/app.py
@@ -81,16 +81,41 @@ async def lifespan(app: FastAPI):
     app.state.skill_registry = skill_registry
 
     # ── Security ────────────────────────────────────────────────────────
+    from steelclaw.security.extended_permissions import CapabilityPermissions
     from steelclaw.security.permissions import PermissionManager
-    from steelclaw.security.sandbox import set_permission_manager
+    from steelclaw.security.sandbox import set_permission_manager, set_sudo_manager
 
     # Resolve approvals file path
     settings.agents.security.approvals_file = str(
         resolve_path(settings.agents.security.approvals_file)
     )
-    permission_manager = PermissionManager(settings.agents.security)
+
+    # Load capability permissions from ~/.steelclaw/permissions.yaml
+    ext_perm_settings = settings.agents.security.extended_permissions
+    capability_permissions = CapabilityPermissions.load(
+        path=ext_perm_settings.permissions_file,
+        auto_create=ext_perm_settings.auto_create_file,
+    )
+
+    permission_manager = PermissionManager(settings.agents.security, capability_permissions)
     set_permission_manager(permission_manager)
     app.state.permission_manager = permission_manager
+    app.state.capability_permissions = capability_permissions
+
+    # Initialise sudo manager if enabled
+    sudo_settings = settings.agents.security.sudo
+    if sudo_settings.enabled:
+        from steelclaw.security.sudo_manager import SudoManager
+        sudo_manager = SudoManager(sudo_settings)
+        set_sudo_manager(sudo_manager)
+        app.state.sudo_manager = sudo_manager
+        logger.info(
+            "Sudo support enabled (audit log: %s, whitelist: %d pattern(s))",
+            sudo_settings.audit_log,
+            len(sudo_settings.whitelist),
+        )
+    else:
+        logger.info("Sudo support disabled (set agents.security.sudo.enabled=true to enable)")
 
     # ── Memory system ────────────────────────────────────────────────────
     from steelclaw.memory.ingestion import MemoryIngestor
@@ -107,6 +132,16 @@ async def lifespan(app: FastAPI):
     app.state.memory_retriever = memory_retriever
     app.state.memory_ingestor = memory_ingestor
 
+    # ── SQLite FTS5 memory (optional fast keyword search) ────────────────
+    fts_store = None
+    fts_settings = settings.agents.memory_fts
+    if fts_settings.enabled:
+        from steelclaw.memory.sqlite_fts import FTSMemoryStore
+        fts_store = FTSMemoryStore(fts_settings.db_path)
+        await fts_store.init()
+        app.state.fts_store = fts_store
+        logger.info("SQLite FTS5 memory store enabled at %s", fts_settings.db_path)
+
     # ── Agent router (LLM-powered multi-agent orchestrator) ────────────
     from steelclaw.agents.orchestrator import MultiAgentOrchestrator
     from steelclaw.gateway.router import set_agent_router, set_memory_ingestor
@@ -116,6 +151,25 @@ async def lifespan(app: FastAPI):
         skill_registry=skill_registry,
     )
     orchestrator.set_memory(memory_retriever, memory_ingestor)
+
+    # ── Skill generator for autonomous skill creation ────────────────────
+    if settings.agents.reflection.enabled:
+        from steelclaw.skills.generator import SkillGenerator
+        from steelclaw.llm.provider import LLMProvider
+
+        _gen_provider = LLMProvider(settings.agents.llm)
+        global_dir = Path(settings.agents.skills.global_dir)
+        skill_generator = SkillGenerator(_gen_provider, global_dir, skill_registry)
+        orchestrator.set_skill_generator(skill_generator)
+        app.state.skill_generator = skill_generator
+        logger.info(
+            "Autonomous skill generator enabled (threshold=%d, auto_create=%s)",
+            settings.agents.reflection.threshold,
+            settings.agents.reflection.skill_auto_create,
+        )
+
+    # Inject skill registry into skill_manager bundled skill
+    _inject_skill_manager(skill_registry, settings.agents.skills)
     set_agent_router(orchestrator)
     set_memory_ingestor(memory_ingestor)
     app.state.agent_router = orchestrator
@@ -208,7 +262,25 @@ async def lifespan(app: FastAPI):
     if hasattr(app.state, "openviking_manager") and app.state.openviking_manager:
         await app.state.openviking_manager.stop()
 
+    # Close FTS5 memory store
+    if hasattr(app.state, "fts_store") and app.state.fts_store:
+        await app.state.fts_store.close()
+
     logger.info("SteelClaw shut down")
+
+
+def _inject_skill_manager(skill_registry, skill_settings) -> None:
+    """Inject the live skill registry into the skill_manager bundled skill."""
+    try:
+        from steelclaw.skills.bundled.skill_manager import _set_registry
+        _set_registry(
+            skill_registry,
+            global_dir=skill_settings.global_dir,
+            workspace_dir=skill_settings.workspace_dir,
+        )
+        logger.debug("Skill manager registry injected")
+    except Exception as exc:
+        logger.debug("Could not inject skill manager registry: %s", exc)
 
 
 async def _ensure_main_agent(settings: Settings) -> None:

--- a/steelclaw/db/models.py
+++ b/steelclaw/db/models.py
@@ -161,3 +161,25 @@ class MemoryEntry(SQLModel, table=True):
     source_type: str = "message"  # "message" | "summary" | "fact"
     metadata_json: Optional[str] = None
     created_at: datetime = Field(default_factory=_now)
+
+
+# ── ReflectionLog ────────────────────────────────────────────────────────────
+
+
+class ReflectionLog(SQLModel, table=True):
+    """Audit log for agent self-reflections and autonomous skill creation attempts.
+
+    Created after the agent completes a task that triggered the reflection
+    threshold (default: 5+ tool calls in a single session).
+    """
+
+    __tablename__ = "reflection_logs"
+
+    id: str = Field(default_factory=_uuid, primary_key=True)
+    agent_id: str = Field(default="", index=True)
+    session_id: str = Field(default="", index=True)
+    tool_call_count: int = Field(default=0)
+    reflection_summary: str = ""  # what the agent reflected on
+    skill_created: Optional[str] = None  # skill name if a new skill was generated
+    skill_path: Optional[str] = None  # path to generated skill directory
+    created_at: datetime = Field(default_factory=_now)

--- a/steelclaw/memory/sqlite_fts.py
+++ b/steelclaw/memory/sqlite_fts.py
@@ -19,22 +19,12 @@ logger = logging.getLogger("steelclaw.memory.fts")
 
 # DDL executed once on first connection
 _SCHEMA_SQL = """
-CREATE TABLE IF NOT EXISTS fts_meta (
-    id        INTEGER PRIMARY KEY AUTOINCREMENT,
-    agent_id  TEXT    NOT NULL DEFAULT '',
-    session_id TEXT   NOT NULL DEFAULT '',
-    source_type TEXT  NOT NULL DEFAULT 'message',
-    tags      TEXT    NOT NULL DEFAULT '',
-    created_at TEXT   NOT NULL
-);
-
 CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
     content,
     tags,
     source_type,
     agent_id      UNINDEXED,
     session_id    UNINDEXED,
-    rowid=id,
     tokenize='porter ascii'
 );
 """

--- a/steelclaw/memory/sqlite_fts.py
+++ b/steelclaw/memory/sqlite_fts.py
@@ -1,0 +1,222 @@
+"""SQLite FTS5 keyword-search memory layer.
+
+Provides fast full-text search over agent memories using SQLite's built-in
+FTS5 extension with Porter stemming.  This complements the vector-based
+semantic memory (ChromaDB / OpenViking) with exact-keyword and stemmed lookup.
+
+The store also supports "memory nudge" prompts: a short formatted string of
+recent relevant memories injected into the agent's system prompt to ground
+responses in past context.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("steelclaw.memory.fts")
+
+# DDL executed once on first connection
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS fts_meta (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id  TEXT    NOT NULL DEFAULT '',
+    session_id TEXT   NOT NULL DEFAULT '',
+    source_type TEXT  NOT NULL DEFAULT 'message',
+    tags      TEXT    NOT NULL DEFAULT '',
+    created_at TEXT   NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+    content,
+    tags,
+    source_type,
+    agent_id      UNINDEXED,
+    session_id    UNINDEXED,
+    rowid=id,
+    tokenize='porter ascii'
+);
+"""
+
+
+class FTSMemoryStore:
+    """Async SQLite FTS5 memory store."""
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = str(Path(db_path).expanduser().resolve())
+        self._db = None  # aiosqlite connection
+
+    async def init(self) -> None:
+        """Create the FTS5 table if it doesn't exist and open the connection."""
+        try:
+            import aiosqlite
+        except ImportError:
+            logger.warning(
+                "aiosqlite not available — FTS memory disabled. "
+                "Install with: pip install aiosqlite"
+            )
+            return
+
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        self._db = await aiosqlite.connect(self._db_path)
+        await self._db.executescript(_SCHEMA_SQL)
+        await self._db.commit()
+        logger.info("FTS memory store initialised at %s", self._db_path)
+
+    async def store(
+        self,
+        content: str,
+        tags: list[str] | None = None,
+        source_type: str = "message",
+        agent_id: str = "",
+        session_id: str = "",
+    ) -> None:
+        """Insert a memory entry into the FTS index."""
+        if self._db is None:
+            return
+        tags_str = " ".join(tags or [])
+        created_at = datetime.now(timezone.utc).isoformat()
+        try:
+            await self._db.execute(
+                """INSERT INTO memory_fts(content, tags, source_type, agent_id, session_id)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (content, tags_str, source_type, agent_id, session_id),
+            )
+            await self._db.commit()
+        except Exception as exc:
+            logger.error("FTS store error: %s", exc)
+
+    async def search(
+        self,
+        query: str,
+        limit: int = 10,
+        agent_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Full-text search returning matching memory entries.
+
+        Returns a list of dicts with keys: content, tags, source_type,
+        agent_id, session_id, rank (lower = more relevant).
+        """
+        if self._db is None:
+            return []
+
+        # Escape special FTS5 characters in the query
+        safe_query = _escape_fts5(query)
+        if not safe_query:
+            return []
+
+        try:
+            if agent_id:
+                cursor = await self._db.execute(
+                    """SELECT content, tags, source_type, agent_id, session_id, rank
+                       FROM memory_fts
+                       WHERE memory_fts MATCH ? AND agent_id = ?
+                       ORDER BY rank
+                       LIMIT ?""",
+                    (safe_query, agent_id, limit),
+                )
+            else:
+                cursor = await self._db.execute(
+                    """SELECT content, tags, source_type, agent_id, session_id, rank
+                       FROM memory_fts
+                       WHERE memory_fts MATCH ?
+                       ORDER BY rank
+                       LIMIT ?""",
+                    (safe_query, limit),
+                )
+            rows = await cursor.fetchall()
+            return [
+                {
+                    "content": r[0],
+                    "tags": r[1],
+                    "source_type": r[2],
+                    "agent_id": r[3],
+                    "session_id": r[4],
+                    "rank": r[5],
+                }
+                for r in rows
+            ]
+        except Exception as exc:
+            logger.error("FTS search error (query=%r): %s", query[:80], exc)
+            return []
+
+    async def recent(
+        self,
+        agent_id: str,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Return the most recently stored entries for *agent_id*."""
+        if self._db is None:
+            return []
+        try:
+            cursor = await self._db.execute(
+                """SELECT content, tags, source_type, agent_id, session_id
+                   FROM memory_fts
+                   WHERE agent_id = ?
+                   ORDER BY rowid DESC
+                   LIMIT ?""",
+                (agent_id, limit),
+            )
+            rows = await cursor.fetchall()
+            return [
+                {
+                    "content": r[0],
+                    "tags": r[1],
+                    "source_type": r[2],
+                    "agent_id": r[3],
+                    "session_id": r[4],
+                }
+                for r in rows
+            ]
+        except Exception as exc:
+            logger.error("FTS recent error: %s", exc)
+            return []
+
+    async def nudge_prompt(
+        self,
+        agent_id: str,
+        limit: int | None = None,
+    ) -> str:
+        """Return a formatted memory-nudge string for system prompt injection.
+
+        Pulls the *limit* most recent memories for *agent_id* and formats them
+        as a short reminder block.  Returns an empty string when nothing is found
+        or the store is unavailable.
+        """
+        nudge_limit = limit or 3
+        entries = await self.recent(agent_id, nudge_limit)
+        if not entries:
+            return ""
+
+        lines = ["[Memory hints from previous sessions:]"]
+        for entry in entries:
+            snippet = entry["content"][:200].replace("\n", " ")
+            src = entry.get("source_type", "")
+            tag = entry.get("tags", "").strip()
+            label = f"[{src}]" if src else ""
+            if tag:
+                label = f"{label}[{tag}]"
+            lines.append(f"- {label} {snippet}")
+
+        return "\n".join(lines)
+
+    async def close(self) -> None:
+        """Close the database connection."""
+        if self._db is not None:
+            await self._db.close()
+            self._db = None
+
+
+def _escape_fts5(query: str) -> str:
+    """Escape a user query string for safe use in FTS5 MATCH expressions.
+
+    Removes characters that have special meaning in FTS5 syntax to prevent
+    query injection and parse errors.
+    """
+    # Remove FTS5 special characters: " ( ) * ^ : -
+    cleaned = "".join(c for c in query if c not in '"()*^:-')
+    # Collapse whitespace and strip
+    return " ".join(cleaned.split())

--- a/steelclaw/memory/sqlite_fts.py
+++ b/steelclaw/memory/sqlite_fts.py
@@ -12,7 +12,6 @@ responses in past context.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -78,7 +77,6 @@ class FTSMemoryStore:
         if self._db is None:
             return
         tags_str = " ".join(tags or [])
-        created_at = datetime.now(timezone.utc).isoformat()
         try:
             await self._db.execute(
                 """INSERT INTO memory_fts(content, tags, source_type, agent_id, session_id)

--- a/steelclaw/security/extended_permissions.py
+++ b/steelclaw/security/extended_permissions.py
@@ -260,7 +260,10 @@ class CapabilityPermissions:
 
         Uses ``Path.is_relative_to()`` (Python 3.9+) for correct prefix
         matching, preventing ``/home/user_backup`` from matching ``/home/user``.
-        Also handles relative paths (e.g. ``../../etc``) via ``resolve()``.
+
+        Every non-flag token is resolved (bare names like ``secret.txt`` become
+        ``<cwd>/secret.txt``) so that commands like ``cat etc/passwd`` are
+        caught even when they don't start with ``/``, ``~``, ``./``, or ``../``.
 
         Args:
             arg_tokens: Already-shlex-parsed argument tokens (not the executable).
@@ -271,13 +274,11 @@ class CapabilityPermissions:
         ]
 
         for token in arg_tokens:
-            # Skip option flags
+            # Skip option flags (e.g. -r, --recursive)
             if token.startswith("-"):
                 continue
-            # Only inspect tokens that look like paths
-            if not (token.startswith("/") or token.startswith("~") or
-                    token.startswith("./") or token.startswith("../")):
-                continue
+            # Resolve ALL non-flag tokens — bare filenames (e.g. "secret.txt",
+            # "etc/passwd") are resolved relative to the current working directory.
             try:
                 resolved = Path(token).expanduser().resolve()
             except Exception:

--- a/steelclaw/security/extended_permissions.py
+++ b/steelclaw/security/extended_permissions.py
@@ -8,7 +8,9 @@ command approval model.
 from __future__ import annotations
 
 import logging
+import os
 import re
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -51,37 +53,73 @@ sudo:
   session_timeout: 30                     # Seconds before approval expires
 """
 
-# Mapping from capability category to command-prefix patterns
-_CATEGORY_PATTERNS: dict[str, list[re.Pattern]] = {
+# Shell operator tokens that separate independent subcommands.
+# We split the full pipeline on these so that chained commands like
+# "ls && curl ..." are each checked against capability rules.
+_CHAIN_SPLIT_RE = re.compile(r"&&|\|\|?|;")
+
+# Mapping from capability category to executable-name patterns.
+# These match against the *first token* of each subcommand (the executable),
+# after the command string has been split on shell chain operators and parsed
+# with shlex.  Using word-boundary anchors on the full first-token avoids the
+# ^ bypass via prepended spaces or subshell wrappers.
+_CATEGORY_EXECUTABLES: dict[str, list[re.Pattern]] = {
     "filesystem": [
-        re.compile(r"^(rm|mv|cp|cat|echo\s+.+>\s*|tee|truncate|touch|mkdir|rmdir|chmod|chown)\b", re.I),
-        re.compile(r"^(find|locate|ls|dir)\b", re.I),
-        re.compile(r">\s*\S"),  # redirect to file
+        re.compile(r"^(rm|mv|cp|cat|tee|truncate|touch|mkdir|rmdir|chmod|chown|find|locate|ls|dir)$", re.I),
+    ],
+    "filesystem_redirect": [
+        # Output-redirect operator anywhere in the raw command string
+        re.compile(r">\s*\S"),
     ],
     "processes": [
-        re.compile(r"^(kill|pkill|killall|systemctl|service|supervisorctl|launchctl)\b", re.I),
+        re.compile(r"^(kill|pkill|killall|systemctl|service|supervisorctl|launchctl)$", re.I),
     ],
     "network": [
-        re.compile(r"^(curl|wget|nc|ncat|netcat|nmap|ssh|scp|rsync|ftp|sftp|dig|host|nslookup)\b", re.I),
-        re.compile(r"^(ping|traceroute|tracepath|mtr|ifconfig|ip\s+addr|netstat|ss)\b", re.I),
+        re.compile(r"^(curl|wget|nc|ncat|netcat|nmap|ssh|scp|rsync|ftp|sftp|dig|host|nslookup|ping|traceroute|tracepath|mtr|ifconfig|netstat|ss)$", re.I),
+        re.compile(r"^ip$", re.I),  # "ip addr", "ip route", etc.
     ],
     "packages": [
-        re.compile(r"^pip\d*\s+(install|uninstall|upgrade)\b", re.I),
-        re.compile(r"^(apt-get|apt|dpkg)\s+(install|remove|purge|upgrade)\b", re.I),
-        re.compile(r"^(brew)\s+(install|uninstall|upgrade|reinstall)\b", re.I),
-        re.compile(r"^npm\s+(install|uninstall|update)\b", re.I),
-        re.compile(r"^(yarn|pnpm)\s+(add|remove|upgrade)\b", re.I),
+        re.compile(r"^pip\d*$", re.I),
+        re.compile(r"^(apt-get|apt|dpkg)$", re.I),
+        re.compile(r"^brew$", re.I),
+        re.compile(r"^npm$", re.I),
+        re.compile(r"^(yarn|pnpm)$", re.I),
     ],
     "environment": [
-        re.compile(r"^(export|unset)\s+\w", re.I),
-        re.compile(r"^(env|printenv|set)\b", re.I),
-        re.compile(r"\.env\b", re.I),
+        re.compile(r"^(export|unset|env|printenv|set)$", re.I),
+        re.compile(r"\.env$", re.I),  # match ".env" file token
     ],
     "cron": [
-        re.compile(r"^(crontab|at|batch|anacron)\b", re.I),
-        re.compile(r"\bcron(tab)?\b", re.I),
+        re.compile(r"^(crontab|at|batch|anacron)$", re.I),
     ],
 }
+
+# Map the internal keys back to the user-facing capability category names
+_EXEC_TO_CATEGORY = {
+    "filesystem": "filesystem",
+    "filesystem_redirect": "filesystem",
+    "processes": "processes",
+    "network": "network",
+    "packages": "packages",
+    "environment": "environment",
+    "cron": "cron",
+}
+
+
+def _split_into_subcommands(command: str) -> list[str]:
+    """Split a shell command string into individual subcommands.
+
+    Handles ``&&``, ``||``, ``;``, and ``|`` pipeline operators as well as
+    subshell constructs ``$(...)`` and ``(...)`` by stripping the wrappers so
+    each token can be examined independently.
+    """
+    # Remove subshell wrappers so "$(curl ...)" → "curl ..."
+    cleaned = re.sub(r"\$\(", " ", command)
+    cleaned = re.sub(r"\(", " ", cleaned)
+    cleaned = re.sub(r"\)", " ", cleaned)
+
+    parts = _CHAIN_SPLIT_RE.split(cleaned)
+    return [p.strip() for p in parts if p.strip()]
 
 
 class CapabilityPermissions:
@@ -125,18 +163,58 @@ class CapabilityPermissions:
     def check_command(self, command: str) -> tuple[bool, str]:
         """Return (allowed, reason) for the given shell command.
 
-        Checks which capability category the command falls into and whether
-        that category is enabled.  Commands that don't match any category
-        are allowed by default.
+        The command is split into individual subcommands on shell chain
+        operators (``&&``, ``||``, ``;``, ``|``) and subshell constructs
+        (``$(...)``, ``(...)``).  Each subcommand's first token (the
+        executable) is matched against category patterns.  This prevents
+        bypasses via command chaining or subshells.
+
+        Commands that don't match any category are allowed by default.
         """
         if not self._capabilities:
-            # No capability rules loaded — allow everything
             return True, ""
 
-        stripped = command.strip()
-        for category, patterns in _CATEGORY_PATTERNS.items():
+        raw = command.strip()
+
+        # Check redirect operator at the whole-command level (filesystem)
+        fs_config = self._capabilities.get("filesystem", {})
+        if not fs_config.get("enabled", True):
+            for pattern in _CATEGORY_EXECUTABLES.get("filesystem_redirect", []):
+                if pattern.search(raw):
+                    reason = "capability 'filesystem' is disabled in ~/.steelclaw/permissions.yaml"
+                    logger.warning("Command blocked by capability rule [filesystem/redirect]: %s", raw[:80])
+                    return False, reason
+
+        # Split into subcommands and check each executable token
+        subcommands = _split_into_subcommands(raw)
+        for subcmd in subcommands:
+            allowed, reason = self._check_subcommand(subcmd, raw)
+            if not allowed:
+                return False, reason
+
+        return True, ""
+
+    def _check_subcommand(self, subcmd: str, full_command: str) -> tuple[bool, str]:
+        """Check a single subcommand (after chain-splitting) against capability rules."""
+        # Parse the subcommand with shlex to get the executable token safely
+        try:
+            tokens = shlex.split(subcmd)
+        except ValueError:
+            # Malformed quoting — fall back to simple whitespace split
+            tokens = subcmd.split()
+
+        if not tokens:
+            return True, ""
+
+        executable = tokens[0].lstrip("-")  # strip leading dashes (e.g. from --option leaks)
+
+        for exec_key, patterns in _CATEGORY_EXECUTABLES.items():
+            category = _EXEC_TO_CATEGORY[exec_key]
+            if exec_key == "filesystem_redirect":
+                continue  # handled at whole-command level above
+
             for pattern in patterns:
-                if pattern.search(stripped):
+                if pattern.match(executable):
                     cap_config = self._capabilities.get(category, {})
                     enabled = cap_config.get("enabled", True)
                     if not enabled:
@@ -145,7 +223,8 @@ class CapabilityPermissions:
                             "~/.steelclaw/permissions.yaml"
                         )
                         logger.warning(
-                            "Command blocked by capability rule [%s]: %s", category, stripped[:80]
+                            "Command blocked by capability rule [%s]: %s",
+                            category, full_command[:80],
                         )
                         return False, reason
 
@@ -153,8 +232,10 @@ class CapabilityPermissions:
                     if category == "packages":
                         allowed_managers = cap_config.get("managers", [])
                         if allowed_managers:
-                            cmd_lower = stripped.lower()
-                            if not any(mgr in cmd_lower for mgr in allowed_managers):
+                            if not any(
+                                executable.lower().startswith(mgr.lower())
+                                for mgr in allowed_managers
+                            ):
                                 return (
                                     False,
                                     f"package manager not in allowed list: {allowed_managers}",
@@ -164,27 +245,47 @@ class CapabilityPermissions:
                     if category == "filesystem":
                         allowed_paths = cap_config.get("allowed_paths", [])
                         if allowed_paths:
-                            allowed, reason = self._check_filesystem_paths(
-                                stripped, allowed_paths
-                            )
-                            if not allowed:
+                            ok, reason = self._check_filesystem_paths(tokens[1:], allowed_paths)
+                            if not ok:
                                 return False, reason
 
                     return True, ""
 
-        # No category matched — allow by default
         return True, ""
 
     def _check_filesystem_paths(
-        self, command: str, allowed_paths: list[str]
+        self, arg_tokens: list[str], allowed_paths: list[str]
     ) -> tuple[bool, str]:
-        """Verify that any absolute paths referenced in the command are within allowed_paths."""
-        expanded = [str(Path(p).expanduser().resolve()) for p in allowed_paths]
-        # Find path-like tokens in the command
-        tokens = re.findall(r"(?:^|\s)((?:/|~)[^\s;|&>]+)", command)
-        for token in tokens:
-            resolved = str(Path(token).expanduser().resolve())
-            if not any(resolved.startswith(ap) for ap in expanded):
+        """Verify that path arguments are within the configured allowed_paths.
+
+        Uses ``Path.is_relative_to()`` (Python 3.9+) for correct prefix
+        matching, preventing ``/home/user_backup`` from matching ``/home/user``.
+        Also handles relative paths (e.g. ``../../etc``) via ``resolve()``.
+
+        Args:
+            arg_tokens: Already-shlex-parsed argument tokens (not the executable).
+            allowed_paths: List of allowed path strings from the config.
+        """
+        expanded_allowed = [
+            Path(p).expanduser().resolve() for p in allowed_paths
+        ]
+
+        for token in arg_tokens:
+            # Skip option flags
+            if token.startswith("-"):
+                continue
+            # Only inspect tokens that look like paths
+            if not (token.startswith("/") or token.startswith("~") or
+                    token.startswith("./") or token.startswith("../")):
+                continue
+            try:
+                resolved = Path(token).expanduser().resolve()
+            except Exception:
+                continue
+
+            if not any(
+                _is_relative_to(resolved, allowed) for allowed in expanded_allowed
+            ):
                 return (
                     False,
                     f"filesystem path '{token}' is outside allowed_paths",
@@ -194,3 +295,19 @@ class CapabilityPermissions:
     def is_category_enabled(self, category: str) -> bool:
         """Return True if the named capability category is enabled."""
         return self._capabilities.get(category, {}).get("enabled", True)
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    """Return True if *path* is equal to or under *parent*.
+
+    Uses ``Path.is_relative_to()`` on Python 3.9+ and falls back to a
+    safe string comparison that appends ``os.sep`` to avoid
+    ``/home/user_backup`` matching ``/home/user``.
+    """
+    try:
+        return path.is_relative_to(parent)
+    except AttributeError:
+        # Python < 3.9 fallback
+        parent_str = str(parent)
+        path_str = str(path)
+        return path_str == parent_str or path_str.startswith(parent_str + os.sep)

--- a/steelclaw/security/extended_permissions.py
+++ b/steelclaw/security/extended_permissions.py
@@ -16,11 +16,16 @@ from typing import Any
 
 logger = logging.getLogger("steelclaw.security.extended_permissions")
 
-# Default permissions.yaml template written when the file is absent
+# Default permissions.yaml template written when the file is absent.
+# NOTE: Sudo settings are configured separately in config.json under
+# "agents.security.sudo".  They are NOT read from this file.
 _DEFAULT_YAML = """\
 # SteelClaw — Extended Capability Permissions
 # Toggle each capability category on or off. Changes take effect on restart.
 # See docs for details on each category.
+#
+# NOTE: Sudo settings (enabled, whitelist, audit_log) are configured in
+# config.json under agents.security.sudo — not here.
 
 capabilities:
   filesystem:
@@ -45,31 +50,23 @@ capabilities:
 
   cron:
     enabled: false  # crontab, at, cron
-
-sudo:
-  enabled: false                          # Master sudo toggle — NEVER auto-approve
-  whitelist: []                           # Glob patterns of pre-approved sudo commands
-  audit_log: "~/.steelclaw/sudo_audit.log"
-  session_timeout: 30                     # Seconds before approval expires
 """
 
-# Shell operator tokens that separate independent subcommands.
-# We split the full pipeline on these so that chained commands like
-# "ls && curl ..." are each checked against capability rules.
-_CHAIN_SPLIT_RE = re.compile(r"&&|\|\|?|;")
+# Shell operator tokens that shlex returns as standalone tokens.
+# These are used to split a tokenised command list into per-subcommand slices.
+_CHAIN_OPS = frozenset({"&&", "||", ";", "|"})
+
+# Regex that matches subshell constructs in the *raw* command string so we
+# can extract their contents before handing the outer command to shlex.
+_SUBSHELL_RE = re.compile(r"\$\(([^)]+)\)|`([^`]+)`")
 
 # Mapping from capability category to executable-name patterns.
 # These match against the *first token* of each subcommand (the executable),
 # after the command string has been split on shell chain operators and parsed
-# with shlex.  Using word-boundary anchors on the full first-token avoids the
-# ^ bypass via prepended spaces or subshell wrappers.
+# with shlex.
 _CATEGORY_EXECUTABLES: dict[str, list[re.Pattern]] = {
     "filesystem": [
         re.compile(r"^(rm|mv|cp|cat|tee|truncate|touch|mkdir|rmdir|chmod|chown|find|locate|ls|dir)$", re.I),
-    ],
-    "filesystem_redirect": [
-        # Output-redirect operator anywhere in the raw command string
-        re.compile(r">\s*\S"),
     ],
     "processes": [
         re.compile(r"^(kill|pkill|killall|systemctl|service|supervisorctl|launchctl)$", re.I),
@@ -94,32 +91,76 @@ _CATEGORY_EXECUTABLES: dict[str, list[re.Pattern]] = {
     ],
 }
 
-# Map the internal keys back to the user-facing capability category names
-_EXEC_TO_CATEGORY = {
-    "filesystem": "filesystem",
-    "filesystem_redirect": "filesystem",
-    "processes": "processes",
-    "network": "network",
-    "packages": "packages",
-    "environment": "environment",
-    "cron": "cron",
-}
-
 
 def _split_into_subcommands(command: str) -> list[str]:
     """Split a shell command string into individual subcommands.
 
-    Handles ``&&``, ``||``, ``;``, and ``|`` pipeline operators as well as
-    subshell constructs ``$(...)`` and ``(...)`` by stripping the wrappers so
-    each token can be examined independently.
-    """
-    # Remove subshell wrappers so "$(curl ...)" → "curl ..."
-    cleaned = re.sub(r"\$\(", " ", command)
-    cleaned = re.sub(r"\(", " ", cleaned)
-    cleaned = re.sub(r"\)", " ", cleaned)
+    Two-phase approach that handles both issues together:
 
-    parts = _CHAIN_SPLIT_RE.split(cleaned)
-    return [p.strip() for p in parts if p.strip()]
+    **Phase 1 – Subshell extraction:** ``$(...)`` and backtick constructs are
+    located in the *raw* string via regex *before* shlex processing.  Their
+    inner content is recursively split and appended to the result.  The
+    constructs are then replaced with a placeholder so the outer command can
+    be cleanly tokenised.  This prevents a subshell like
+    ``echo $(curl evil.com)`` from hiding ``curl`` inside ``echo``'s
+    argument list.
+
+    **Phase 2 – Operator-aware tokenisation:** The placeholder-substituted
+    outer command is tokenised with ``shlex.split()``, which respects quoted
+    strings.  Any operator token (``&&``, ``||``, ``;``, ``|``) in the
+    resulting list marks a subcommand boundary.  This prevents a command like
+    ``git commit -m "fix; issue"`` from being incorrectly split on the ``;``
+    inside the quoted message.
+    """
+    result: list[str] = []
+
+    # Phase 1: extract subshell commands from raw string before shlex.
+    for m in _SUBSHELL_RE.finditer(command):
+        inner = (m.group(1) or m.group(2) or "").strip()
+        if inner:
+            result.extend(_split_into_subcommands(inner))
+
+    # Replace subshell constructs with a neutral placeholder so shlex can
+    # tokenise the outer command without hitting unbalanced-paren errors.
+    outer = _SUBSHELL_RE.sub(" __subshell__ ", command)
+
+    # Phase 2: shlex-tokenise to respect quoted strings, then split on operators.
+    try:
+        tokens = shlex.split(outer)
+    except ValueError:
+        # Malformed quoting — fall back to simple whitespace split (less precise)
+        tokens = outer.split()
+
+    current: list[str] = []
+    for token in tokens:
+        if token in _CHAIN_OPS:
+            if current:
+                result.append(" ".join(current))
+                current = []
+        elif token != "__subshell__":
+            current.append(token)
+
+    if current:
+        result.append(" ".join(current))
+
+    return result if result else [command.strip()]
+
+
+def _has_redirect_operator(command: str) -> bool:
+    """Return True if the command contains a shell output-redirect operator.
+
+    Uses ``shlex.split()`` to tokenise so that ``>`` inside a quoted string
+    (e.g. ``echo "Value > 10"``) does not produce a false positive.  Falls
+    back to a simple regex scan if tokenisation fails (e.g. unbalanced quotes).
+    """
+    try:
+        tokens = shlex.split(command)
+        # shlex returns '>' as a standalone token and '>file' as a single token
+        # starting with '>'.  Both indicate a redirect operator.
+        return any(t == ">" or t == ">>" or t.startswith(">") for t in tokens)
+    except ValueError:
+        # Fallback: regex on raw string (may produce false positives for broken input)
+        return bool(re.search(r">\s*\S", command))
 
 
 class CapabilityPermissions:
@@ -127,6 +168,15 @@ class CapabilityPermissions:
 
     def __init__(self, config: dict[str, Any]) -> None:
         self._capabilities: dict[str, dict] = config.get("capabilities", {})
+        # Pre-resolve allowed_paths for each category once at construction time
+        # to avoid repeated filesystem calls on every check_command invocation.
+        self._resolved_allowed_paths: dict[str, list[Path]] = {}
+        for cat, cap_cfg in self._capabilities.items():
+            paths = cap_cfg.get("allowed_paths", [])
+            if paths:
+                self._resolved_allowed_paths[cat] = [
+                    Path(p).expanduser().resolve() for p in paths
+                ]
 
     @classmethod
     def load(cls, path: str, auto_create: bool = True) -> "CapabilityPermissions":
@@ -163,11 +213,9 @@ class CapabilityPermissions:
     def check_command(self, command: str) -> tuple[bool, str]:
         """Return (allowed, reason) for the given shell command.
 
-        The command is split into individual subcommands on shell chain
-        operators (``&&``, ``||``, ``;``, ``|``) and subshell constructs
-        (``$(...)``, ``(...)``).  Each subcommand's first token (the
-        executable) is matched against category patterns.  This prevents
-        bypasses via command chaining or subshells.
+        The command is split into individual subcommands respecting shell chain
+        operators and quoted strings (see ``_split_into_subcommands``).  Each
+        subcommand's executable is matched against category patterns.
 
         Commands that don't match any category are allowed by default.
         """
@@ -176,14 +224,14 @@ class CapabilityPermissions:
 
         raw = command.strip()
 
-        # Check redirect operator at the whole-command level (filesystem)
+        # Check redirect operator using shlex-aware detection (avoids false
+        # positives for '>' inside quoted strings like echo "Value > 10").
         fs_config = self._capabilities.get("filesystem", {})
         if not fs_config.get("enabled", True):
-            for pattern in _CATEGORY_EXECUTABLES.get("filesystem_redirect", []):
-                if pattern.search(raw):
-                    reason = "capability 'filesystem' is disabled in ~/.steelclaw/permissions.yaml"
-                    logger.warning("Command blocked by capability rule [filesystem/redirect]: %s", raw[:80])
-                    return False, reason
+            if _has_redirect_operator(raw):
+                reason = "capability 'filesystem' is disabled in ~/.steelclaw/permissions.yaml"
+                logger.warning("Command blocked by capability rule [filesystem/redirect]: %s", raw[:80])
+                return False, reason
 
         # Split into subcommands and check each executable token
         subcommands = _split_into_subcommands(raw)
@@ -200,19 +248,15 @@ class CapabilityPermissions:
         try:
             tokens = shlex.split(subcmd)
         except ValueError:
-            # Malformed quoting — fall back to simple whitespace split
             tokens = subcmd.split()
 
         if not tokens:
             return True, ""
 
-        executable = tokens[0].lstrip("-")  # strip leading dashes (e.g. from --option leaks)
+        executable = tokens[0].lstrip("-")
 
         for exec_key, patterns in _CATEGORY_EXECUTABLES.items():
-            category = _EXEC_TO_CATEGORY[exec_key]
-            if exec_key == "filesystem_redirect":
-                continue  # handled at whole-command level above
-
+            category = exec_key  # keys are the same as category names now
             for pattern in patterns:
                 if pattern.match(executable):
                     cap_config = self._capabilities.get(category, {})
@@ -241,11 +285,11 @@ class CapabilityPermissions:
                                     f"package manager not in allowed list: {allowed_managers}",
                                 )
 
-                    # Extra check: filesystem path restrictions
+                    # Extra check: filesystem path restrictions (uses pre-resolved paths)
                     if category == "filesystem":
-                        allowed_paths = cap_config.get("allowed_paths", [])
-                        if allowed_paths:
-                            ok, reason = self._check_filesystem_paths(tokens[1:], allowed_paths)
+                        resolved_allowed = self._resolved_allowed_paths.get(category, [])
+                        if resolved_allowed:
+                            ok, reason = self._check_filesystem_paths(tokens[1:], resolved_allowed)
                             if not ok:
                                 return False, reason
 
@@ -254,39 +298,25 @@ class CapabilityPermissions:
         return True, ""
 
     def _check_filesystem_paths(
-        self, arg_tokens: list[str], allowed_paths: list[str]
+        self, arg_tokens: list[str], resolved_allowed: list[Path]
     ) -> tuple[bool, str]:
         """Verify that path arguments are within the configured allowed_paths.
 
-        Uses ``Path.is_relative_to()`` (Python 3.9+) for correct prefix
-        matching, preventing ``/home/user_backup`` from matching ``/home/user``.
+        Uses pre-resolved ``Path`` objects (computed once in ``__init__``) and
+        ``Path.is_relative_to()`` for correct prefix matching.
 
-        Every non-flag token is resolved (bare names like ``secret.txt`` become
-        ``<cwd>/secret.txt``) so that commands like ``cat etc/passwd`` are
-        caught even when they don't start with ``/``, ``~``, ``./``, or ``../``.
-
-        Args:
-            arg_tokens: Already-shlex-parsed argument tokens (not the executable).
-            allowed_paths: List of allowed path strings from the config.
+        Every non-flag token is resolved so that bare filenames like
+        ``secret.txt`` (which become ``<cwd>/secret.txt``) are caught too.
         """
-        expanded_allowed = [
-            Path(p).expanduser().resolve() for p in allowed_paths
-        ]
-
         for token in arg_tokens:
-            # Skip option flags (e.g. -r, --recursive)
             if token.startswith("-"):
-                continue
-            # Resolve ALL non-flag tokens — bare filenames (e.g. "secret.txt",
-            # "etc/passwd") are resolved relative to the current working directory.
+                continue  # skip option flags
             try:
                 resolved = Path(token).expanduser().resolve()
             except Exception:
                 continue
 
-            if not any(
-                _is_relative_to(resolved, allowed) for allowed in expanded_allowed
-            ):
+            if not any(_is_relative_to(resolved, allowed) for allowed in resolved_allowed):
                 return (
                     False,
                     f"filesystem path '{token}' is outside allowed_paths",
@@ -308,7 +338,6 @@ def _is_relative_to(path: Path, parent: Path) -> bool:
     try:
         return path.is_relative_to(parent)
     except AttributeError:
-        # Python < 3.9 fallback
         parent_str = str(parent)
         path_str = str(path)
         return path_str == parent_str or path_str.startswith(parent_str + os.sep)

--- a/steelclaw/security/extended_permissions.py
+++ b/steelclaw/security/extended_permissions.py
@@ -254,11 +254,12 @@ class CapabilityPermissions:
             return True, ""
 
         executable = tokens[0].lstrip("-")
+        executable_name = os.path.basename(executable)
 
         for exec_key, patterns in _CATEGORY_EXECUTABLES.items():
             category = exec_key  # keys are the same as category names now
             for pattern in patterns:
-                if pattern.match(executable):
+                if pattern.match(executable_name):
                     cap_config = self._capabilities.get(category, {})
                     enabled = cap_config.get("enabled", True)
                     if not enabled:

--- a/steelclaw/security/extended_permissions.py
+++ b/steelclaw/security/extended_permissions.py
@@ -1,0 +1,196 @@
+"""Extended capability-level permission system backed by ~/.steelclaw/permissions.yaml.
+
+Provides granular, category-based toggles (filesystem, processes, network,
+packages, environment, cron) that layer on top of the existing three-tier
+command approval model.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("steelclaw.security.extended_permissions")
+
+# Default permissions.yaml template written when the file is absent
+_DEFAULT_YAML = """\
+# SteelClaw — Extended Capability Permissions
+# Toggle each capability category on or off. Changes take effect on restart.
+# See docs for details on each category.
+
+capabilities:
+  filesystem:
+    enabled: true
+    # Restrict to specific paths (empty = all paths allowed)
+    allowed_paths: []
+    # Allowed operations (read, write, delete)
+    operations: [read, write, delete]
+
+  processes:
+    enabled: true  # kill, pkill, systemctl, service
+
+  network:
+    enabled: false  # curl, wget, nc, nmap, ssh
+
+  packages:
+    enabled: false  # pip install, apt-get install, brew install, npm install
+    managers: []    # e.g. [pip, apt]
+
+  environment:
+    enabled: true   # export, env, printenv, .env modifications
+
+  cron:
+    enabled: false  # crontab, at, cron
+
+sudo:
+  enabled: false                          # Master sudo toggle — NEVER auto-approve
+  whitelist: []                           # Glob patterns of pre-approved sudo commands
+  audit_log: "~/.steelclaw/sudo_audit.log"
+  session_timeout: 30                     # Seconds before approval expires
+"""
+
+# Mapping from capability category to command-prefix patterns
+_CATEGORY_PATTERNS: dict[str, list[re.Pattern]] = {
+    "filesystem": [
+        re.compile(r"^(rm|mv|cp|cat|echo\s+.+>\s*|tee|truncate|touch|mkdir|rmdir|chmod|chown)\b", re.I),
+        re.compile(r"^(find|locate|ls|dir)\b", re.I),
+        re.compile(r">\s*\S"),  # redirect to file
+    ],
+    "processes": [
+        re.compile(r"^(kill|pkill|killall|systemctl|service|supervisorctl|launchctl)\b", re.I),
+    ],
+    "network": [
+        re.compile(r"^(curl|wget|nc|ncat|netcat|nmap|ssh|scp|rsync|ftp|sftp|dig|host|nslookup)\b", re.I),
+        re.compile(r"^(ping|traceroute|tracepath|mtr|ifconfig|ip\s+addr|netstat|ss)\b", re.I),
+    ],
+    "packages": [
+        re.compile(r"^pip\d*\s+(install|uninstall|upgrade)\b", re.I),
+        re.compile(r"^(apt-get|apt|dpkg)\s+(install|remove|purge|upgrade)\b", re.I),
+        re.compile(r"^(brew)\s+(install|uninstall|upgrade|reinstall)\b", re.I),
+        re.compile(r"^npm\s+(install|uninstall|update)\b", re.I),
+        re.compile(r"^(yarn|pnpm)\s+(add|remove|upgrade)\b", re.I),
+    ],
+    "environment": [
+        re.compile(r"^(export|unset)\s+\w", re.I),
+        re.compile(r"^(env|printenv|set)\b", re.I),
+        re.compile(r"\.env\b", re.I),
+    ],
+    "cron": [
+        re.compile(r"^(crontab|at|batch|anacron)\b", re.I),
+        re.compile(r"\bcron(tab)?\b", re.I),
+    ],
+}
+
+
+class CapabilityPermissions:
+    """Loads and evaluates capability-level permission rules from permissions.yaml."""
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        self._capabilities: dict[str, dict] = config.get("capabilities", {})
+
+    @classmethod
+    def load(cls, path: str, auto_create: bool = True) -> "CapabilityPermissions":
+        """Load permissions from *path*, creating a default file if absent."""
+        try:
+            import yaml  # PyYAML is a transitive dependency
+        except ImportError:
+            logger.warning(
+                "PyYAML not available — extended permissions disabled. "
+                "Install with: pip install pyyaml"
+            )
+            return cls({})
+
+        p = Path(path).expanduser().resolve()
+
+        if not p.exists():
+            if auto_create:
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(_DEFAULT_YAML, encoding="utf-8")
+                logger.info("Created default permissions file: %s", p)
+            else:
+                logger.info("Permissions file not found, using permissive defaults: %s", p)
+                return cls({})
+
+        try:
+            with p.open(encoding="utf-8") as fh:
+                data = yaml.safe_load(fh) or {}
+            logger.info("Loaded extended permissions from %s", p)
+            return cls(data)
+        except Exception as exc:
+            logger.error("Failed to parse permissions.yaml (%s): %s — using defaults", p, exc)
+            return cls({})
+
+    def check_command(self, command: str) -> tuple[bool, str]:
+        """Return (allowed, reason) for the given shell command.
+
+        Checks which capability category the command falls into and whether
+        that category is enabled.  Commands that don't match any category
+        are allowed by default.
+        """
+        if not self._capabilities:
+            # No capability rules loaded — allow everything
+            return True, ""
+
+        stripped = command.strip()
+        for category, patterns in _CATEGORY_PATTERNS.items():
+            for pattern in patterns:
+                if pattern.search(stripped):
+                    cap_config = self._capabilities.get(category, {})
+                    enabled = cap_config.get("enabled", True)
+                    if not enabled:
+                        reason = (
+                            f"capability '{category}' is disabled in "
+                            "~/.steelclaw/permissions.yaml"
+                        )
+                        logger.warning(
+                            "Command blocked by capability rule [%s]: %s", category, stripped[:80]
+                        )
+                        return False, reason
+
+                    # Extra check: package managers whitelist
+                    if category == "packages":
+                        allowed_managers = cap_config.get("managers", [])
+                        if allowed_managers:
+                            cmd_lower = stripped.lower()
+                            if not any(mgr in cmd_lower for mgr in allowed_managers):
+                                return (
+                                    False,
+                                    f"package manager not in allowed list: {allowed_managers}",
+                                )
+
+                    # Extra check: filesystem path restrictions
+                    if category == "filesystem":
+                        allowed_paths = cap_config.get("allowed_paths", [])
+                        if allowed_paths:
+                            allowed, reason = self._check_filesystem_paths(
+                                stripped, allowed_paths
+                            )
+                            if not allowed:
+                                return False, reason
+
+                    return True, ""
+
+        # No category matched — allow by default
+        return True, ""
+
+    def _check_filesystem_paths(
+        self, command: str, allowed_paths: list[str]
+    ) -> tuple[bool, str]:
+        """Verify that any absolute paths referenced in the command are within allowed_paths."""
+        expanded = [str(Path(p).expanduser().resolve()) for p in allowed_paths]
+        # Find path-like tokens in the command
+        tokens = re.findall(r"(?:^|\s)((?:/|~)[^\s;|&>]+)", command)
+        for token in tokens:
+            resolved = str(Path(token).expanduser().resolve())
+            if not any(resolved.startswith(ap) for ap in expanded):
+                return (
+                    False,
+                    f"filesystem path '{token}' is outside allowed_paths",
+                )
+        return True, ""
+
+    def is_category_enabled(self, category: str) -> bool:
+        """Return True if the named capability category is enabled."""
+        return self._capabilities.get(category, {}).get("enabled", True)

--- a/steelclaw/security/permissions.py
+++ b/steelclaw/security/permissions.py
@@ -4,6 +4,10 @@ Tiers:
   - "ask":    Prompt the user via WebSocket before executing.
   - "record": Log the action but allow execution.
   - "ignore": Auto-allow silently.
+
+Extended capability permissions from ~/.steelclaw/permissions.yaml are checked
+*before* the approval store, allowing category-level (network, packages, etc.)
+blocking independent of individual command rules.
 """
 
 from __future__ import annotations
@@ -21,12 +25,20 @@ ApprovalCallback = Callable[[str], Coroutine[Any, Any, bool]]
 
 
 class PermissionManager:
-    """Evaluates command permission using the three-tier model."""
+    """Evaluates command permission using the three-tier model.
 
-    def __init__(self, settings: SecuritySettings) -> None:
+    Optionally integrates with CapabilityPermissions for category-level blocking.
+    """
+
+    def __init__(
+        self,
+        settings: SecuritySettings,
+        capability_permissions=None,  # Optional[CapabilityPermissions]
+    ) -> None:
         self._settings = settings
         self._approvals = ApprovalStore(settings.approvals_file)
         self._approval_callback: ApprovalCallback | None = None
+        self._capability_permissions = capability_permissions
 
     def set_approval_callback(self, callback: ApprovalCallback) -> None:
         """Set the callback used to prompt the user when permission is 'ask'."""
@@ -36,6 +48,12 @@ class PermissionManager:
         """Check whether a command is allowed to execute.
 
         Returns a PermissionResult with the decision and any relevant metadata.
+
+        Check order:
+        1. Blocked commands (hardcoded dangerous patterns)
+        2. Capability permissions (YAML category-level rules)
+        3. Approval store (per-command glob rules)
+        4. Default permission tier (ask / record / ignore)
         """
         # Check blocked commands first
         if self._is_blocked(command):
@@ -45,6 +63,16 @@ class PermissionManager:
                 tier="blocked",
                 reason="Command matches a blocked pattern",
             )
+
+        # Check capability-level permissions (from permissions.yaml)
+        if self._capability_permissions is not None:
+            allowed, reason = self._capability_permissions.check_command(command)
+            if not allowed:
+                return PermissionResult(
+                    allowed=False,
+                    tier="blocked",
+                    reason=reason,
+                )
 
         # Check approval store
         stored = self._approvals.check(command)

--- a/steelclaw/security/sandbox.py
+++ b/steelclaw/security/sandbox.py
@@ -13,6 +13,8 @@ logger = logging.getLogger("steelclaw.security.sandbox")
 
 # Module-level permission manager — set during app startup
 _permission_manager = None
+# Module-level sudo manager — set during app startup when sudo is enabled
+_sudo_manager = None
 
 
 def set_permission_manager(pm: object) -> None:
@@ -20,20 +22,40 @@ def set_permission_manager(pm: object) -> None:
     _permission_manager = pm
 
 
+def set_sudo_manager(sm: object) -> None:
+    """Register the sudo manager for privileged command execution."""
+    global _sudo_manager
+    _sudo_manager = sm
+
+
 async def execute_command(
     command: str,
     timeout: int = 30,
     working_directory: str | None = None,
     check_permissions: bool = True,
+    sudo: bool = False,
 ) -> str:
     """Execute a shell command in a sandboxed subprocess.
 
     Security measures:
     - Permission check via the three-tier model
+    - Capability-level category checks (filesystem, network, etc.)
     - Timeout enforcement
     - Working directory validation
     - Output size limits
+
+    When *sudo=True*, the command is routed through the SudoManager which
+    requires explicit "YES" confirmation and writes an immutable audit log entry.
     """
+    # Route sudo commands through the dedicated sudo manager
+    if sudo:
+        if _sudo_manager is None:
+            return (
+                "Error: sudo support is not enabled. "
+                "Set agents.security.sudo.enabled = true in config.json."
+            )
+        return await _sudo_manager.execute_sudo(command, timeout=timeout)
+
     from steelclaw.security.permissions import PermissionManager
 
     # Permission check

--- a/steelclaw/security/sudo_manager.py
+++ b/steelclaw/security/sudo_manager.py
@@ -1,0 +1,166 @@
+"""Sudo command execution with explicit user confirmation and immutable audit logging.
+
+Design principles:
+- Master toggle disabled by default (zero auto-approval)
+- Requires the user to type the literal string "YES" (not "yes", not "y")
+- Every approval or denial is appended to an append-only audit log
+- An optional command whitelist skips the interactive prompt for pre-approved patterns
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fnmatch
+import logging
+import shlex
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Coroutine
+
+logger = logging.getLogger("steelclaw.security.sudo")
+
+# Callback type: async fn(prompt_text: str) -> str
+SudoConfirmCallback = Callable[[str], Coroutine[Any, Any, str]]
+
+
+class SudoManager:
+    """Manages privileged command execution with strict confirmation requirements."""
+
+    def __init__(self, sudo_config) -> None:
+        """
+        Args:
+            sudo_config: SudoSettings instance from steelclaw.settings.
+        """
+        self._config = sudo_config
+        self._audit_path = Path(sudo_config.audit_log).expanduser().resolve()
+        self._confirm_callback: SudoConfirmCallback | None = None
+
+    def set_confirm_callback(self, callback: SudoConfirmCallback) -> None:
+        """Register the async callback used to prompt the user for confirmation."""
+        self._confirm_callback = callback
+
+    async def execute_sudo(
+        self,
+        command: str,
+        timeout: int | None = None,
+    ) -> str:
+        """Execute *command* with sudo after mandatory user confirmation.
+
+        Returns the command output on success, or a descriptive error string.
+
+        Confirmation rules:
+        - Whitelisted commands (glob match) are approved automatically.
+        - All other commands require the user to reply with the exact string
+          "YES" (uppercase, no trailing spaces) within *session_timeout* seconds.
+        - Any other response — including "yes", "y", "ok" — is treated as a denial.
+        """
+        if not self._config.enabled:
+            return (
+                "Error: sudo support is not enabled. "
+                "Set agents.security.sudo.enabled = true in config.json to enable it."
+            )
+
+        timeout = timeout or self._config.session_timeout
+
+        # Check whitelist first (no prompt needed for pre-approved patterns)
+        if self._is_whitelisted(command):
+            logger.info("Sudo command auto-approved via whitelist: %s", command[:80])
+            self._write_audit("AUTO-APPROVED (whitelist)", command)
+            return await self._run_sudo(command, timeout)
+
+        # Interactive confirmation required
+        if self._confirm_callback is None:
+            self._write_audit("DENIED (no callback)", command)
+            return (
+                "Error: sudo confirmation channel is not available. "
+                "Cannot execute privileged commands without user approval."
+            )
+
+        prompt = (
+            f"\u26a0\ufe0f  **Sudo command requested**\n"
+            f"`sudo {command}`\n\n"
+            f"Type **YES** (exactly, uppercase) to confirm, or anything else to cancel:"
+        )
+
+        try:
+            response = await asyncio.wait_for(
+                self._confirm_callback(prompt),
+                timeout=float(timeout),
+            )
+        except asyncio.TimeoutError:
+            self._write_audit("DENIED (timeout)", command)
+            logger.warning("Sudo confirmation timed out for: %s", command[:80])
+            return f"Error: sudo confirmation timed out after {timeout}s"
+
+        # Strict "YES" check — no case folding, no trimming beyond stripping newlines
+        confirmed = isinstance(response, str) and response.strip() == "YES"
+
+        if not confirmed:
+            self._write_audit("DENIED (user)", command)
+            logger.info("User denied sudo command: %s", command[:80])
+            return "sudo command denied: confirmation required (type YES to approve)"
+
+        self._write_audit("APPROVED", command)
+        return await self._run_sudo(command, timeout)
+
+    async def _run_sudo(self, command: str, timeout: int) -> str:
+        """Actually run the command prefixed with sudo."""
+        try:
+            full_cmd = f"sudo {command}"
+            process = await asyncio.create_subprocess_shell(
+                full_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=float(timeout),
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.communicate()
+                return f"Error: sudo command timed out after {timeout}s"
+
+            parts = []
+            stdout_text = stdout.decode("utf-8", errors="replace").strip()
+            stderr_text = stderr.decode("utf-8", errors="replace").strip()
+
+            if stdout_text:
+                parts.append(stdout_text)
+            if stderr_text:
+                parts.append(f"STDERR:\n{stderr_text}")
+
+            output = "\n".join(parts) if parts else "(no output)"
+            if process.returncode != 0:
+                output = f"Exit code: {process.returncode}\n{output}"
+
+            logger.info("Sudo command completed (rc=%s): %s", process.returncode, command[:80])
+            return output
+
+        except Exception as exc:
+            logger.exception("Sudo execution failed: %s", command)
+            return f"Error executing sudo command: {exc}"
+
+    def _is_whitelisted(self, command: str) -> bool:
+        """Return True if the command matches any whitelist glob pattern."""
+        for pattern in self._config.whitelist:
+            if fnmatch.fnmatch(command, pattern) or fnmatch.fnmatch(command.lower(), pattern.lower()):
+                return True
+        return False
+
+    def _write_audit(self, status: str, command: str) -> None:
+        """Append an immutable audit entry to the audit log file.
+
+        The log is opened in append mode ('a') — entries are never deleted.
+        """
+        try:
+            self._audit_path.parent.mkdir(parents=True, exist_ok=True)
+            timestamp = datetime.now(timezone.utc).isoformat()
+            entry = f"[{timestamp}] [{status}] cmd={command!r}\n"
+            with self._audit_path.open("a", encoding="utf-8") as fh:
+                fh.write(entry)
+        except Exception as exc:
+            logger.error("Failed to write sudo audit log: %s", exc)

--- a/steelclaw/security/sudo_manager.py
+++ b/steelclaw/security/sudo_manager.py
@@ -145,9 +145,14 @@ class SudoManager:
             return f"Error executing sudo command: {exc}"
 
     def _is_whitelisted(self, command: str) -> bool:
-        """Return True if the command matches any whitelist glob pattern."""
+        """Return True if the command matches any whitelist glob pattern.
+
+        Matching is case-sensitive because Linux command names and paths are
+        case-sensitive.  Using case-insensitive matching could allow ``RunMe``
+        to match a whitelist entry of ``runme``, granting unintended access.
+        """
         for pattern in self._config.whitelist:
-            if fnmatch.fnmatch(command, pattern) or fnmatch.fnmatch(command.lower(), pattern.lower()):
+            if fnmatch.fnmatch(command, pattern):
                 return True
         return False
 

--- a/steelclaw/security/sudo_manager.py
+++ b/steelclaw/security/sudo_manager.py
@@ -4,7 +4,8 @@ Design principles:
 - Master toggle disabled by default (zero auto-approval)
 - Requires the user to type the literal string "YES" (not "yes", not "y")
 - Every approval or denial is appended to an append-only audit log
-- An optional command whitelist skips the interactive prompt for pre-approved patterns
+- An optional whitelist skips the interactive prompt for pre-approved executables
+- Commands are parsed with shlex and run via exec (not shell) to prevent injection
 """
 
 from __future__ import annotations
@@ -12,16 +13,36 @@ from __future__ import annotations
 import asyncio
 import fnmatch
 import logging
+import os
 import shlex
-import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Coroutine
 
 logger = logging.getLogger("steelclaw.security.sudo")
 
+# Maximum output size returned to the caller (matches sandbox.py)
+_MAX_OUTPUT = 50_000
+
 # Callback type: async fn(prompt_text: str) -> str
 SudoConfirmCallback = Callable[[str], Coroutine[Any, Any, str]]
+
+
+def _get_sanitised_env() -> dict[str, str]:
+    """Return a copy of the environment with sensitive variables removed.
+
+    Mirrors the sanitisation in steelclaw.security.sandbox to prevent
+    credentials leaking into the sudo subprocess environment.
+    """
+    env = dict(os.environ)
+    sensitive = [
+        "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+        "GITHUB_TOKEN", "GH_TOKEN",
+        "DATABASE_URL", "DATABASE_PASSWORD",
+    ]
+    for key in sensitive:
+        env.pop(key, None)
+    return env
 
 
 class SudoManager:
@@ -105,13 +126,29 @@ class SudoManager:
         return await self._run_sudo(command, timeout)
 
     async def _run_sudo(self, command: str, timeout: int) -> str:
-        """Actually run the command prefixed with sudo."""
+        """Run a sudo command using exec (not shell) to prevent injection.
+
+        The command is parsed with ``shlex.split()`` and passed as an argument
+        list to ``create_subprocess_exec``.  This prevents shell metacharacters
+        in *command* (e.g. ``;``, ``&&``, ``|``) from being interpreted by a
+        shell.  Environment is sanitised to avoid credential leakage.
+        Output is truncated at ``_MAX_OUTPUT`` characters to prevent memory
+        exhaustion from verbose commands.
+        """
         try:
-            full_cmd = f"sudo {command}"
-            process = await asyncio.create_subprocess_shell(
-                full_cmd,
+            args = shlex.split(command)
+        except ValueError as exc:
+            return f"Error: could not parse sudo command arguments: {exc}"
+
+        if not args:
+            return "Error: empty command"
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "sudo", *args,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                env=_get_sanitised_env(),
             )
 
             try:
@@ -137,6 +174,10 @@ class SudoManager:
             if process.returncode != 0:
                 output = f"Exit code: {process.returncode}\n{output}"
 
+            # Truncate to prevent memory exhaustion
+            if len(output) > _MAX_OUTPUT:
+                output = output[:_MAX_OUTPUT] + f"\n... (truncated, {len(output)} total chars)"
+
             logger.info("Sudo command completed (rc=%s): %s", process.returncode, command[:80])
             return output
 
@@ -145,14 +186,22 @@ class SudoManager:
             return f"Error executing sudo command: {exc}"
 
     def _is_whitelisted(self, command: str) -> bool:
-        """Return True if the command matches any whitelist glob pattern.
+        """Return True if the command's *executable* matches a whitelist pattern.
 
-        Matching is case-sensitive because Linux command names and paths are
-        case-sensitive.  Using case-insensitive matching could allow ``RunMe``
-        to match a whitelist entry of ``runme``, granting unintended access.
+        Only the parsed executable (first token after shlex splitting) is
+        matched against patterns.  Matching on the full raw command string with
+        a shell-glob pattern is dangerous: ``ls *`` would match ``ls; rm -rf /``
+        allowing shell injection when combined with ``create_subprocess_shell``.
         """
+        try:
+            parts = shlex.split(command)
+        except ValueError:
+            return False
+        if not parts:
+            return False
+        executable = parts[0]
         for pattern in self._config.whitelist:
-            if fnmatch.fnmatch(command, pattern):
+            if fnmatch.fnmatch(executable, pattern):
                 return True
         return False
 

--- a/steelclaw/settings.py
+++ b/steelclaw/settings.py
@@ -109,6 +109,38 @@ class SessionLifecycleSettings(BaseModel):
     heartbeat_interval_seconds: int = 60
 
 
+class SudoSettings(BaseModel):
+    """Sudo command execution configuration (disabled by default for safety)."""
+
+    enabled: bool = False
+    whitelist: list[str] = []  # glob patterns of pre-approved sudo commands
+    audit_log: str = "~/.steelclaw/sudo_audit.log"
+    session_timeout: int = 30  # seconds before sudo session expires
+
+
+class ExtendedPermissionsSettings(BaseModel):
+    """YAML-based capability permission toggles."""
+
+    permissions_file: str = "~/.steelclaw/permissions.yaml"
+    auto_create_file: bool = True  # write default permissions.yaml if absent
+
+
+class ReflectionSettings(BaseModel):
+    """Agent self-reflection and autonomous skill creation."""
+
+    enabled: bool = False
+    threshold: int = 5  # minimum tool calls before triggering reflection
+    skill_auto_create: bool = False  # actually write generated skill files to disk
+
+
+class MemoryFTSSettings(BaseModel):
+    """SQLite FTS5 keyword-search memory layer."""
+
+    enabled: bool = False
+    db_path: str = "~/.steelclaw/memory_fts.db"
+    nudge_limit: int = 3  # number of recent memories to include in nudge prompt
+
+
 class SecuritySettings(BaseModel):
     """Execution security configuration."""
 
@@ -117,6 +149,8 @@ class SecuritySettings(BaseModel):
     sandbox_enabled: bool = True
     max_command_timeout: int = 30
     blocked_commands: list[str] = ["rm -rf /", "mkfs", "dd if=", ":(){:|:&};:"]
+    sudo: SudoSettings = SudoSettings()
+    extended_permissions: ExtendedPermissionsSettings = ExtendedPermissionsSettings()
 
 
 class SchedulerSettings(BaseModel):
@@ -155,6 +189,8 @@ class AgentSettings(BaseModel):
     voice: VoiceSettings = VoiceSettings()
     memory: MemorySettings = MemorySettings()
     session_lifecycle: SessionLifecycleSettings = SessionLifecycleSettings()
+    reflection: ReflectionSettings = ReflectionSettings()
+    memory_fts: MemoryFTSSettings = MemoryFTSSettings()
 
 
 class Settings(BaseSettings):

--- a/steelclaw/skills/bundled/skill_manager/SKILL.md
+++ b/steelclaw/skills/bundled/skill_manager/SKILL.md
@@ -1,0 +1,52 @@
+# Skill Manager
+
+Manage SteelClaw skills at runtime — list, create, edit, delete, and reload
+skills from the global skill directory (~/.steelclaw/skills/) or the workspace
+directory (.steelclaw/skills/).  Bundled skills (read-only) can be listed but
+not deleted or edited through this skill.
+
+## Metadata
+- version: 1.0.0
+- author: SteelClaw
+- triggers: skill, skills, manage skill, create skill, list skills, delete skill, reload skills, install skill
+
+## System Prompt
+You are a skill management assistant. You can list all available skills, create
+new skills by scaffolding SKILL.md and __init__.py files, edit existing skill
+descriptions or tool definitions, delete workspace/global skills, and reload
+the skill registry after changes.
+
+When asked to create a skill, confirm the name and description with the user
+before writing files.  When deleting, always confirm the name and scope.
+
+## Tools
+
+### list_skills
+List all currently loaded skills with their name, scope, description, and enabled status.
+
+### create_skill
+Scaffold a new skill in the global skills directory (~/.steelclaw/skills/).
+
+**Parameters:**
+- `name` (string, required): Snake-case skill directory name (e.g. my_skill).
+- `description` (string, required): One-sentence description of what the skill does.
+- `tools_spec` (string): Optional JSON array of tool specs: [{"name": "...", "description": "...", "parameters": [...]}].
+
+### edit_skill
+Edit a section of an existing skill's SKILL.md or replace its __init__.py.
+
+**Parameters:**
+- `name` (string, required): Skill directory name.
+- `file` (string, required): Either "SKILL.md" or "__init__.py".
+- `content` (string, required): New complete content for the file.
+
+### delete_skill
+Delete a skill from the global or workspace directory.  Cannot delete bundled skills.
+
+**Parameters:**
+- `name` (string, required): Skill directory name to delete.
+- `scope` (string): "global" (default) or "workspace".
+
+### reload_skills
+Reload the skill registry from all discovery paths (bundled, global, workspace).
+Call this after creating or editing skills to make changes take effect immediately.

--- a/steelclaw/skills/bundled/skill_manager/__init__.py
+++ b/steelclaw/skills/bundled/skill_manager/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil
 from pathlib import Path
 from typing import Any
@@ -132,12 +133,21 @@ async def tool_edit_skill(
     if file not in ("SKILL.md", "__init__.py"):
         return "Error: file must be 'SKILL.md' or '__init__.py'"
 
+    # Sanitise name to prevent path traversal (e.g. "../../etc")
+    safe_name = re.sub(r"[^a-z0-9_]", "_", name.lower().strip()).strip("_")
+    if not safe_name:
+        return "Error: invalid skill name"
+
     # Try global first, then workspace
     for scope_dir in (
         Path(_global_skills_dir).expanduser(),
         Path(_workspace_skills_dir).expanduser(),
     ):
-        skill_dir = scope_dir / name
+        base = scope_dir.resolve()
+        skill_dir = base / safe_name
+        # Ensure the resolved path is actually inside the expected base (defence-in-depth)
+        if not str(skill_dir).startswith(str(base)):
+            return "Error: invalid skill path"
         target = skill_dir / file
         if skill_dir.exists():
             if target.exists() or file == "SKILL.md":
@@ -145,7 +155,7 @@ async def tool_edit_skill(
                 return f"Updated {target}\nRun `reload_skills` to apply changes."
 
     return (
-        f"Error: skill '{name}' not found in global or workspace directories. "
+        f"Error: skill '{safe_name}' not found in global or workspace directories. "
         "Bundled skills cannot be edited."
     )
 
@@ -160,21 +170,31 @@ async def tool_delete_skill(
         name: Skill directory name to delete.
         scope: "global" (default) or "workspace".
     """
+    # Sanitise name to prevent path traversal (e.g. "../../etc")
+    safe_name = re.sub(r"[^a-z0-9_]", "_", name.lower().strip()).strip("_")
+    if not safe_name:
+        return "Error: invalid skill name"
+
     if scope == "global":
-        skill_dir = Path(_global_skills_dir).expanduser().resolve() / name
+        base = Path(_global_skills_dir).expanduser().resolve()
     elif scope == "workspace":
-        skill_dir = Path(_workspace_skills_dir).expanduser().resolve() / name
+        base = Path(_workspace_skills_dir).expanduser().resolve()
     else:
         return f"Error: scope must be 'global' or 'workspace', got '{scope}'"
 
+    skill_dir = base / safe_name
+    # Ensure the resolved path is actually inside the expected base (defence-in-depth)
+    if not str(skill_dir.resolve()).startswith(str(base)):
+        return "Error: invalid skill path"
+
     if not skill_dir.exists():
-        return f"Error: skill '{name}' not found at {skill_dir}"
+        return f"Error: skill '{safe_name}' not found at {skill_dir}"
 
     try:
         shutil.rmtree(skill_dir)
-        return f"Skill '{name}' deleted from {skill_dir}\nRun `reload_skills` to apply."
+        return f"Skill '{safe_name}' deleted from {skill_dir}\nRun `reload_skills` to apply."
     except Exception as exc:
-        return f"Error deleting skill '{name}': {exc}"
+        return f"Error deleting skill '{safe_name}': {exc}"
 
 
 async def tool_reload_skills() -> str:

--- a/steelclaw/skills/bundled/skill_manager/__init__.py
+++ b/steelclaw/skills/bundled/skill_manager/__init__.py
@@ -1,0 +1,238 @@
+"""Skill Manager — runtime skill lifecycle management tool."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("steelclaw.skills.skill_manager")
+
+# ── Module-level registry reference (injected by app.py) ─────────────────────
+
+_skill_registry = None
+_global_skills_dir: str = "~/.steelclaw/skills"
+_workspace_skills_dir: str = ".steelclaw/skills"
+
+
+def _set_registry(registry, global_dir: str = "", workspace_dir: str = "") -> None:
+    """Called by app startup to inject the live skill registry."""
+    global _skill_registry, _global_skills_dir, _workspace_skills_dir
+    _skill_registry = registry
+    if global_dir:
+        _global_skills_dir = global_dir
+    if workspace_dir:
+        _workspace_skills_dir = workspace_dir
+
+
+# ── Tool functions ────────────────────────────────────────────────────────────
+
+
+async def tool_list_skills() -> str:
+    """List all currently loaded skills with metadata."""
+    if _skill_registry is None:
+        return "Error: skill registry not available"
+
+    skills = _skill_registry.list_skills()
+    if not skills:
+        return "No skills currently loaded."
+
+    rows = []
+    for skill in skills:
+        meta = skill.metadata
+        enabled = "enabled" if skill.default_enabled else "disabled"
+        rows.append(
+            f"- **{meta.name}** [{skill.scope}] [{enabled}]\n"
+            f"  {meta.description or '(no description)'}"
+        )
+
+    return f"## Loaded Skills ({len(skills)})\n\n" + "\n".join(rows)
+
+
+async def tool_create_skill(
+    name: str,
+    description: str,
+    tools_spec: str = "",
+) -> str:
+    """Scaffold a new skill in the global skills directory.
+
+    Args:
+        name: Snake-case skill directory name (e.g. my_skill).
+        description: One-sentence description of the skill.
+        tools_spec: Optional JSON array of tool specs.
+    """
+    # Sanitise name
+    import re
+    safe_name = re.sub(r"[^a-z0-9_]", "_", name.lower().strip()).strip("_")
+    if not safe_name:
+        return "Error: invalid skill name"
+
+    skill_dir = Path(_global_skills_dir).expanduser().resolve() / safe_name
+
+    if skill_dir.exists():
+        return f"Error: skill '{safe_name}' already exists at {skill_dir}"
+
+    # Build SKILL.md content
+    tools_section = _build_tools_section(tools_spec)
+    skill_md = f"""# {safe_name.replace("_", " ").title()}
+
+{description}
+
+## Metadata
+- version: 0.1.0
+- author: user
+
+## System Prompt
+You are a specialist assistant for {description.rstrip(".").lower()}.
+
+## Tools
+{tools_section}
+"""
+
+    # Build __init__.py content
+    tool_names = _extract_tool_names(tools_spec, safe_name)
+    init_lines = ['"""Auto-scaffolded skill: ' + safe_name + '."""', "", "from __future__ import annotations", ""]
+    for tool_name in tool_names:
+        init_lines += [
+            f"",
+            f"async def tool_{tool_name}(input: str) -> str:",
+            f'    """Execute {tool_name.replace("_", " ")}."""',
+            f"    # TODO: implement this tool",
+            f'    return f"tool_{tool_name} called with: {{input}}"',
+        ]
+
+    init_py = "\n".join(init_lines) + "\n"
+
+    try:
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+        (skill_dir / "__init__.py").write_text(init_py, encoding="utf-8")
+        return (
+            f"Skill '{safe_name}' created at {skill_dir}\n"
+            f"Run `reload_skills` to activate it, then edit __init__.py to implement the tools."
+        )
+    except Exception as exc:
+        return f"Error creating skill '{safe_name}': {exc}"
+
+
+async def tool_edit_skill(
+    name: str,
+    file: str,
+    content: str,
+) -> str:
+    """Replace a skill file (SKILL.md or __init__.py).
+
+    Args:
+        name: Skill directory name.
+        file: "SKILL.md" or "__init__.py".
+        content: New complete file content.
+    """
+    if file not in ("SKILL.md", "__init__.py"):
+        return "Error: file must be 'SKILL.md' or '__init__.py'"
+
+    # Try global first, then workspace
+    for scope_dir in (
+        Path(_global_skills_dir).expanduser(),
+        Path(_workspace_skills_dir).expanduser(),
+    ):
+        skill_dir = scope_dir / name
+        target = skill_dir / file
+        if skill_dir.exists():
+            if target.exists() or file == "SKILL.md":
+                target.write_text(content, encoding="utf-8")
+                return f"Updated {target}\nRun `reload_skills` to apply changes."
+
+    return (
+        f"Error: skill '{name}' not found in global or workspace directories. "
+        "Bundled skills cannot be edited."
+    )
+
+
+async def tool_delete_skill(
+    name: str,
+    scope: str = "global",
+) -> str:
+    """Delete a skill from the global or workspace directory.
+
+    Args:
+        name: Skill directory name to delete.
+        scope: "global" (default) or "workspace".
+    """
+    if scope == "global":
+        skill_dir = Path(_global_skills_dir).expanduser().resolve() / name
+    elif scope == "workspace":
+        skill_dir = Path(_workspace_skills_dir).expanduser().resolve() / name
+    else:
+        return f"Error: scope must be 'global' or 'workspace', got '{scope}'"
+
+    if not skill_dir.exists():
+        return f"Error: skill '{name}' not found at {skill_dir}"
+
+    try:
+        shutil.rmtree(skill_dir)
+        return f"Skill '{name}' deleted from {skill_dir}\nRun `reload_skills` to apply."
+    except Exception as exc:
+        return f"Error deleting skill '{name}': {exc}"
+
+
+async def tool_reload_skills() -> str:
+    """Reload the skill registry from all discovery paths."""
+    if _skill_registry is None:
+        return "Error: skill registry not available"
+
+    try:
+        _skill_registry.load_all()
+        skills = _skill_registry.list_skills()
+        return f"Skills reloaded. {len(skills)} skill(s) now active."
+    except Exception as exc:
+        return f"Error reloading skills: {exc}"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _build_tools_section(tools_spec: str) -> str:
+    """Build the ## Tools section from an optional JSON spec."""
+    if not tools_spec:
+        return _default_tool_section()
+
+    try:
+        specs = json.loads(tools_spec)
+        if not isinstance(specs, list) or not specs:
+            return _default_tool_section()
+
+        lines = []
+        for spec in specs:
+            tool_name = spec.get("name", "tool")
+            tool_desc = spec.get("description", "")
+            lines.append(f"\n### {tool_name}")
+            lines.append(tool_desc)
+            params = spec.get("parameters", [])
+            if params:
+                lines.append("\n**Parameters:**")
+                for p in params:
+                    req = ", required" if p.get("required") else ""
+                    lines.append(f"- `{p['name']}` ({p.get('type','string')}{req}): {p.get('description','')}")
+
+        return "\n".join(lines)
+    except (json.JSONDecodeError, TypeError):
+        return _default_tool_section()
+
+
+def _default_tool_section() -> str:
+    return "\n### run\nExecute the primary action of this skill.\n\n**Parameters:**\n- `input` (string, required): The input to process."
+
+
+def _extract_tool_names(tools_spec: str, fallback: str) -> list[str]:
+    """Extract tool names from a tools_spec JSON string."""
+    if tools_spec:
+        try:
+            specs = json.loads(tools_spec)
+            names = [s.get("name") for s in specs if s.get("name")]
+            if names:
+                return names
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return [fallback]

--- a/steelclaw/skills/bundled/skill_manager/__init__.py
+++ b/steelclaw/skills/bundled/skill_manager/__init__.py
@@ -92,10 +92,13 @@ You are a specialist assistant for {description.rstrip(".").lower()}.
 {tools_section}
 """
 
-    # Build __init__.py content
+    # Build __init__.py content — sanitize every tool name before embedding in Python source
     tool_names = _extract_tool_names(tools_spec, safe_name)
     init_lines = ['"""Auto-scaffolded skill: ' + safe_name + '."""', "", "from __future__ import annotations", ""]
-    for tool_name in tool_names:
+    for raw_tool_name in tool_names:
+        # Re-sanitize here even though _extract_tool_names already does it, as a
+        # defence-in-depth safeguard before injecting into generated Python source.
+        tool_name = re.sub(r"[^a-z0-9_]", "_", raw_tool_name.lower().strip()).strip("_") or "run"
         init_lines += [
             f"",
             f"async def tool_{tool_name}(input: str) -> str:",
@@ -246,13 +249,24 @@ def _default_tool_section() -> str:
 
 
 def _extract_tool_names(tools_spec: str, fallback: str) -> list[str]:
-    """Extract tool names from a tools_spec JSON string."""
+    """Extract and sanitize tool names from a tools_spec JSON string.
+
+    Tool names are sanitized to valid Python identifiers to prevent code
+    injection when names are embedded into generated Python source files.
+    """
     if tools_spec:
         try:
             specs = json.loads(tools_spec)
-            names = [s.get("name") for s in specs if s.get("name")]
-            if names:
-                return names
+            raw_names = [s.get("name") for s in specs if s.get("name")]
+            if raw_names:
+                sanitized = [
+                    re.sub(r"[^a-z0-9_]", "_", n.lower().strip()).strip("_")
+                    for n in raw_names
+                ]
+                # Filter out empty names that became empty after sanitization
+                valid = [n for n in sanitized if n]
+                if valid:
+                    return valid
         except (json.JSONDecodeError, TypeError):
             pass
     return [fallback]

--- a/steelclaw/skills/bundled/skill_manager/__init__.py
+++ b/steelclaw/skills/bundled/skill_manager/__init__.py
@@ -65,7 +65,6 @@ async def tool_create_skill(
         tools_spec: Optional JSON array of tool specs.
     """
     # Sanitise name
-    import re
     safe_name = re.sub(r"[^a-z0-9_]", "_", name.lower().strip()).strip("_")
     if not safe_name:
         return "Error: invalid skill name"

--- a/steelclaw/skills/generator.py
+++ b/steelclaw/skills/generator.py
@@ -1,0 +1,298 @@
+"""Autonomous skill generator — reflects on recent tool calls and creates reusable skills.
+
+After the agent completes a task that required N+ tool calls (configurable via
+``reflection.threshold``), the SkillGenerator analyses the tool-call pattern and:
+
+1. Decides whether a reusable skill would be valuable.
+2. Generates a SKILL.md + __init__.py using the LLM.
+3. Validates the generated SKILL.md can be parsed without errors.
+4. If ``skill_auto_create=True``, writes the files to ``~/.steelclaw/skills/<name>/``
+   and triggers a hot-reload of the skill registry.
+
+When ``skill_auto_create=False`` (the safe default), the reflection is only
+*logged* — no files are written, but the reasoning is preserved in the database
+for manual review.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from steelclaw.llm.provider import LLMProvider
+    from steelclaw.skills.registry import SkillRegistry
+
+logger = logging.getLogger("steelclaw.skills.generator")
+
+# Prompt asking the LLM to decide whether a skill is worth creating
+_REFLECT_PROMPT = textwrap.dedent("""\
+    You are a meta-agent reviewing your own recent tool-call history to identify
+    patterns that could be packaged into a reusable skill.
+
+    ## Recent tool calls
+    {tool_calls_summary}
+
+    ## Task context
+    {task_context}
+
+    ## Instructions
+    1. Analyse the tool calls for a repeated or composable pattern.
+    2. If a valuable reusable skill can be distilled, reply with a JSON object:
+       {{
+         "should_create": true,
+         "skill_name": "snake_case_name",   // e.g. "git_helper"
+         "description": "One-sentence description",
+         "skill_md": "<full SKILL.md content>",
+         "init_py": "<full __init__.py content with async tool_ functions>"
+       }}
+    3. If no skill is warranted, reply with:
+       {{
+         "should_create": false,
+         "reason": "Brief explanation"
+       }}
+
+    Respond with ONLY the JSON — no additional text.
+""")
+
+# Minimal SKILL.md template used as a fallback if LLM output is malformed
+_SKILL_MD_TEMPLATE = """\
+# {skill_name}
+
+{description}
+
+## Metadata
+- version: 0.1.0
+- author: SteelClaw AutoGen
+
+## System Prompt
+You are a specialist in {description_lower}. Use the provided tools to help the user.
+
+## Tools
+
+### {tool_name}
+Perform the core operation of this skill.
+
+**Parameters:**
+- `input` (string, required): The input to process.
+"""
+
+# Minimal __init__.py template
+_INIT_PY_TEMPLATE = '''\
+"""Auto-generated skill: {skill_name}."""
+
+from __future__ import annotations
+
+
+async def tool_{tool_name}(input: str) -> str:
+    """Perform the core operation of this skill."""
+    # TODO: implement this skill
+    return f"Skill {skill_name!r} received: {{input}}"
+'''
+
+
+class SkillGenerator:
+    """Reflects on tool-call history and optionally creates new skills."""
+
+    def __init__(
+        self,
+        llm_provider: "LLMProvider",
+        global_skills_dir: Path,
+        skill_registry: "SkillRegistry | None" = None,
+    ) -> None:
+        self._provider = llm_provider
+        self._global_dir = Path(global_skills_dir).expanduser().resolve()
+        self._registry = skill_registry
+
+    def set_registry(self, registry: "SkillRegistry") -> None:
+        """Inject the skill registry for hot-reload after skill creation."""
+        self._registry = registry
+
+    async def reflect_and_create(
+        self,
+        tool_calls_log: list[dict[str, Any]],
+        task_context: str,
+        skill_auto_create: bool = False,
+    ) -> dict[str, Any]:
+        """Analyse tool-call history and optionally generate a new skill.
+
+        Args:
+            tool_calls_log: List of dicts with keys ``name`` and ``arguments``.
+            task_context: Short description of the overall task.
+            skill_auto_create: If True, write generated files to disk.
+
+        Returns:
+            A result dict with keys:
+            - ``reflected``: bool
+            - ``should_create``: bool
+            - ``skill_name``: str or None
+            - ``skill_path``: str or None
+            - ``reason``: str (explanation)
+        """
+        result: dict[str, Any] = {
+            "reflected": True,
+            "should_create": False,
+            "skill_name": None,
+            "skill_path": None,
+            "reason": "",
+        }
+
+        if not tool_calls_log:
+            result["reflected"] = False
+            result["reason"] = "No tool calls to reflect on"
+            return result
+
+        # Summarise the tool calls for the prompt
+        tool_calls_summary = _summarise_tool_calls(tool_calls_log)
+
+        prompt_text = _REFLECT_PROMPT.format(
+            tool_calls_summary=tool_calls_summary,
+            task_context=task_context or "General task",
+        )
+
+        try:
+            response = await self._provider.complete(
+                messages=[
+                    {"role": "system", "content": "You are a meta-reasoning agent."},
+                    {"role": "user", "content": prompt_text},
+                ],
+                tools=None,
+            )
+        except Exception as exc:
+            logger.warning("Reflection LLM call failed: %s", exc)
+            result["reason"] = f"LLM call failed: {exc}"
+            return result
+
+        raw = (response.content or "").strip()
+        parsed = _parse_json_response(raw)
+
+        if parsed is None:
+            logger.warning("Reflection response was not valid JSON: %s", raw[:200])
+            result["reason"] = "Could not parse LLM reflection response"
+            return result
+
+        if not parsed.get("should_create"):
+            result["reason"] = parsed.get("reason", "LLM decided no skill needed")
+            logger.info("Reflection: no skill created — %s", result["reason"])
+            return result
+
+        # LLM wants to create a skill
+        skill_name = _sanitise_name(parsed.get("skill_name", "auto_skill"))
+        description = parsed.get("description", "Auto-generated skill")
+        skill_md = parsed.get("skill_md") or _SKILL_MD_TEMPLATE.format(
+            skill_name=skill_name.replace("_", " ").title(),
+            description=description,
+            description_lower=description.lower(),
+            tool_name=skill_name,
+        )
+        init_py = parsed.get("init_py") or _INIT_PY_TEMPLATE.format(
+            skill_name=skill_name,
+            tool_name=skill_name,
+        )
+
+        # Validate SKILL.md before writing
+        if not _validate_skill_md(skill_md, skill_name):
+            result["reason"] = "Generated SKILL.md failed validation"
+            return result
+
+        result["should_create"] = True
+        result["skill_name"] = skill_name
+
+        if not skill_auto_create:
+            result["reason"] = (
+                f"Skill '{skill_name}' identified but auto-create is disabled. "
+                "Enable agents.reflection.skill_auto_create to write it to disk."
+            )
+            logger.info("Reflection: would create skill '%s' (auto-create disabled)", skill_name)
+            return result
+
+        # Write files to ~/.steelclaw/skills/<skill_name>/
+        try:
+            skill_path = self._save_skill(skill_name, skill_md, init_py)
+            result["skill_path"] = str(skill_path)
+            result["reason"] = f"Skill '{skill_name}' created at {skill_path}"
+            logger.info("Autonomous skill created: %s", skill_path)
+
+            # Hot-reload the registry
+            if self._registry is not None:
+                self._registry.load_all()
+                logger.info("Skill registry reloaded after autonomous creation")
+        except Exception as exc:
+            logger.error("Failed to write skill '%s': %s", skill_name, exc)
+            result["should_create"] = False
+            result["reason"] = f"Failed to write skill files: {exc}"
+
+        return result
+
+    def _save_skill(self, name: str, skill_md: str, init_py: str) -> Path:
+        """Write skill files to ~/.steelclaw/skills/<name>/."""
+        skill_dir = self._global_dir / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+
+        (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+        (skill_dir / "__init__.py").write_text(init_py, encoding="utf-8")
+
+        return skill_dir
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _summarise_tool_calls(tool_calls: list[dict[str, Any]]) -> str:
+    """Format tool calls into a compact human-readable summary."""
+    lines = []
+    for i, tc in enumerate(tool_calls, 1):
+        name = tc.get("name", "unknown")
+        args = tc.get("arguments", {})
+        args_str = json.dumps(args, ensure_ascii=False)[:120]
+        lines.append(f"{i}. {name}({args_str})")
+    return "\n".join(lines)
+
+
+def _parse_json_response(text: str) -> dict | None:
+    """Extract and parse a JSON object from the LLM response."""
+    # Try direct parse first
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Try extracting JSON block from markdown code fences
+    match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if match:
+        try:
+            return json.loads(match.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    # Try finding raw JSON object in text
+    match2 = re.search(r"\{.*\}", text, re.DOTALL)
+    if match2:
+        try:
+            return json.loads(match2.group(0))
+        except json.JSONDecodeError:
+            pass
+
+    return None
+
+
+def _sanitise_name(name: str) -> str:
+    """Convert a skill name to a safe snake_case directory name."""
+    name = name.lower().strip()
+    name = re.sub(r"[^a-z0-9_]", "_", name)
+    name = re.sub(r"_+", "_", name).strip("_")
+    return name or "auto_skill"
+
+
+def _validate_skill_md(skill_md: str, skill_name: str) -> bool:
+    """Return True if the SKILL.md can be parsed without errors."""
+    try:
+        from steelclaw.skills.parser import parse_skill_md
+        metadata = parse_skill_md(skill_md, fallback_name=skill_name)
+        return bool(metadata.name)
+    except Exception as exc:
+        logger.warning("SKILL.md validation failed for '%s': %s", skill_name, exc)
+        return False


### PR DESCRIPTION
… & Self-Improving Architecture (issue #7)

## Changes

### Extended System Permissions (permissions.yaml)
- New `steelclaw/security/extended_permissions.py` with `CapabilityPermissions` class
- YAML-based per-category toggles: filesystem, processes, network, packages, environment, cron
- Auto-creates default `~/.steelclaw/permissions.yaml` on first run
- Integrated into `PermissionManager.check_command()` as a pre-filter before the approval store
- New settings: `agents.security.extended_permissions.{permissions_file, auto_create_file}`

### Sudo Command Execution
- New `steelclaw/security/sudo_manager.py` with `SudoManager` class
- Master toggle disabled by default (`agents.security.sudo.enabled = false`)
- Requires literal "YES" (uppercase, exact) confirmation — never auto-approved
- Immutable append-only audit log at `~/.steelclaw/sudo_audit.log`
- Optional command whitelist with glob pattern matching
- Wired into `sandbox.execute_command(sudo=True)` via new `set_sudo_manager()` setter
- New settings: `agents.security.sudo.{enabled, whitelist, audit_log, session_timeout}`

### Autonomous Skill Creation (Self-Improving Architecture)
- New `steelclaw/skills/generator.py` with `SkillGenerator` class
- Reflects on recent tool-call history using the LLM after N calls (threshold=5 default)
- Generates SKILL.md + __init__.py and validates via existing parser before writing
- Fire-and-forget: does not block agent response
- `skill_auto_create=false` by default — logs reflection without writing files
- New settings: `agents.reflection.{enabled, threshold, skill_auto_create}`
- New `ReflectionLog` DB table for audit trail of reflection attempts

### Skill Management Tool
- New bundled skill `steelclaw/skills/bundled/skill_manager/`
- Tools: list_skills, create_skill, edit_skill, delete_skill, reload_skills
- Scaffold new global/workspace skills; cannot edit/delete bundled skills
- Registry injected at startup via `_inject_skill_manager()`

### SQLite FTS5 Memory Layer
- New `steelclaw/memory/sqlite_fts.py` with async FTS5 store using Porter stemming
- `store()`, `search()`, `recent()`, and `nudge_prompt()` methods
- `nudge_prompt()` returns formatted memory hints for system prompt injection
- Complements vector memory (ChromaDB/OpenViking) with fast keyword search
- New settings: `agents.memory_fts.{enabled, db_path, nudge_limit}`

### <think> Reasoning Blocks
- Agent router now strips `<think>...</think>` blocks from LLM responses
- Applies to both streaming and non-streaming paths
- Think content logged at DEBUG level for developer inspection
- Router imports: added `_strip_think_blocks()` and `_extract_think_blocks()` helpers

### All existing 197 tests pass. New features are opt-in with safe defaults.

https://claude.ai/code/session_01Kjdo39ks8XuknSn7KjMyQt