### PR TITLE
fix(security): fix approval popup buttons, add sudo password modal

### DIFF
--- a/steelclaw/gateway/base.py
+++ b/steelclaw/gateway/base.py
@@ -172,6 +172,20 @@ class BaseConnector(ABC):
         )
         await self.send(message)
 
+    async def send_permission_resolved(self, resolved_data: dict) -> None:
+        """Notify this connector that a permission request has been resolved.
+
+        Called by the broadcaster after any channel (web, Telegram, etc.)
+        resolves a permission request. Subclasses may override to update
+        native UI (e.g. edit an inline-keyboard message in Telegram).
+        The default implementation is a no-op.
+
+        Args:
+            resolved_data: Dict from ResolvedRequest.to_dict() containing
+                request_id, decision, resolved_by, original_command.
+        """
+        pass
+
     async def _on_permission_response(
         self, request_id: str, decision: str, user_id: str
     ) -> None:

--- a/steelclaw/gateway/connectors/telegram.py
+++ b/steelclaw/gateway/connectors/telegram.py
@@ -515,3 +515,38 @@ class TelegramConnector(BaseConnector):
                 # Clean up pending permission
                 if hasattr(self, "_pending_permissions"):
                     self._pending_permissions.pop(request_id, None)
+
+    async def send_permission_resolved(self, resolved_data: dict) -> None:
+        """Edit the inline-keyboard message to show the final result."""
+        import httpx
+
+        request_id = resolved_data.get("request_id", "")
+        if not hasattr(self, "_pending_permissions"):
+            return
+
+        pending = self._pending_permissions.pop(request_id, None)
+        if not pending:
+            return  # Already handled by _handle_callback_query
+
+        chat_id, msg_id = pending
+        decision = resolved_data.get("decision", "unknown")
+        resolved_by = resolved_data.get("resolved_by", "another channel")
+
+        if decision == "approve_once":
+            result_text = f"🔒 Permission Request\n✅ Approved once by {resolved_by}"
+        elif decision == "approve_session":
+            result_text = f"🔒 Permission Request\n✅ Approved for session by {resolved_by}"
+        else:
+            result_text = f"🔒 Permission Request\n❌ Denied by {resolved_by}"
+
+        token = self.config.token
+        if not token:
+            return
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                await client.post(
+                    f"https://api.telegram.org/bot{token}/editMessageText",
+                    json={"chat_id": chat_id, "message_id": msg_id, "text": result_text},
+                )
+        except Exception:
+            logger.debug("Failed to update resolved permission message in Telegram")

--- a/steelclaw/gateway/router.py
+++ b/steelclaw/gateway/router.py
@@ -330,6 +330,11 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                 await _handle_permission_response(websocket, data)
                 continue
 
+            # Handle sudo password response messages
+            if data.get("type") == "sudo_password_response":
+                await _handle_sudo_password_response(websocket, data)
+                continue
+
             # Check if client supports streaming
             stream_mode = data.get("stream", False)
 
@@ -464,6 +469,28 @@ async def _handle_permission_response(websocket: WebSocket, data: dict) -> None:
             "type": "permission_response_ack",
             "data": {"request_id": request_id, "success": False, "reason": "Already resolved or unknown request"},
         }))
+
+
+async def _handle_sudo_password_response(websocket: WebSocket, data: dict) -> None:
+    """Handle sudo_password_response message from WebSocket client."""
+    logger.info("Received sudo_password_response")
+    broadcaster = get_broadcaster()
+    if not broadcaster:
+        return
+
+    payload = data.get("data", data)
+    request_id = payload.get("request_id")
+    # password is None when the user cancelled the modal
+    password = payload.get("password")
+
+    if not request_id:
+        return
+
+    resolved = await broadcaster.resolve_sudo_password(request_id, password)
+    await websocket.send_text(json.dumps({
+        "type": "sudo_password_response_ack",
+        "data": {"request_id": request_id, "success": resolved},
+    }))
 
 
 def get_ws_connections() -> dict[str, WebSocket]:

--- a/steelclaw/security/broadcaster.py
+++ b/steelclaw/security/broadcaster.py
@@ -30,6 +30,7 @@ class PermissionBroadcaster:
 
     Uses first-response-wins semantics. When any user responds, all other
     channels receive a permission_resolved message to dismiss their UI.
+    Also handles sudo password requests via a separate popup flow.
     """
 
     def __init__(self, timeout_seconds: int = 300) -> None:
@@ -40,6 +41,9 @@ class PermissionBroadcaster:
         self._connector_registry: Optional["ConnectorRegistry"] = None
         # Function to get WebSocket connections dynamically
         self._get_ws_connections: Optional[Callable[[], set]] = None
+        # Sudo password request tracking
+        self._sudo_password_events: dict[str, asyncio.Event] = {}
+        self._sudo_password_results: dict[str, Optional[str]] = {}
 
     def set_ws_connections_getter(self, getter: Callable[[], set]) -> None:
         """Set function to get WebSocket connections. Called from gateway/router.py."""
@@ -219,16 +223,108 @@ class PermissionBroadcaster:
                 except Exception:
                     pass
 
-        # Broadcast to connectors
+        # Notify connectors via dedicated resolution method
         if self._connector_registry:
             for platform, connector in self._connector_registry._connectors.items():
                 try:
-                    await connector.send_permission_request(
-                        "",  # No specific chat_id for resolution broadcast
-                        message,
-                    )
+                    await connector.send_permission_resolved(resolved.to_dict())
                 except Exception:
                     pass
+
+    async def request_sudo_password(
+        self,
+        request_id: str,
+        command: str,
+        timeout_seconds: Optional[int] = None,
+        context: Optional[str] = None,
+    ) -> Optional[str]:
+        """Request a sudo password from the user via a UI popup.
+
+        Broadcasts a sudo_password_request message to all connected WebSocket
+        clients and waits for the user to submit their password. Returns the
+        password string on success, or None if the user cancels or times out.
+        """
+        timeout = timeout_seconds or self._timeout
+        event = asyncio.Event()
+        self._sudo_password_events[request_id] = event
+
+        message = {
+            "type": "sudo_password_request",
+            "data": {
+                "request_id": request_id,
+                "command": command,
+                "context": context,
+                "timeout_seconds": timeout,
+            },
+        }
+
+        # Send to all WebSocket clients
+        ws_connections = None
+        if self._get_ws_connections:
+            try:
+                ws_connections = self._get_ws_connections()
+            except Exception:
+                pass
+
+        if ws_connections:
+            for ws in list(ws_connections):
+                try:
+                    await ws.send_json(message)
+                except Exception as e:
+                    logger.debug("Failed to send sudo_password_request to WebSocket: %s", e)
+        else:
+            logger.warning("No WebSocket connections for sudo password request %s", request_id)
+            self._sudo_password_events.pop(request_id, None)
+            return None
+
+        try:
+            await asyncio.wait_for(event.wait(), timeout=float(timeout))
+        except asyncio.TimeoutError:
+            logger.warning("Sudo password request %s timed out", request_id)
+            return None
+        finally:
+            self._sudo_password_events.pop(request_id, None)
+
+        return self._sudo_password_results.pop(request_id, None)
+
+    async def resolve_sudo_password(self, request_id: str, password: Optional[str]) -> bool:
+        """Resolve a pending sudo password request.
+
+        Called from the WebSocket handler when the user submits or cancels
+        the sudo password modal. Returns True if the request was found and
+        resolved, False if it was unknown or already resolved.
+        """
+        event = self._sudo_password_events.get(request_id)
+        if not event:
+            logger.warning("Unknown sudo password request: %s", request_id)
+            return False
+
+        self._sudo_password_results[request_id] = password
+        event.set()
+
+        # Notify WebSocket clients to dismiss the modal
+        resolved_message = {
+            "type": "sudo_password_resolved",
+            "data": {
+                "request_id": request_id,
+                "success": password is not None,
+            },
+        }
+        ws_connections = None
+        if self._get_ws_connections:
+            try:
+                ws_connections = self._get_ws_connections()
+            except Exception:
+                pass
+
+        if ws_connections:
+            for ws in list(ws_connections):
+                try:
+                    await ws.send_json(resolved_message)
+                except Exception:
+                    pass
+
+        return True
 
 
 # Global broadcaster instance

--- a/steelclaw/security/sudo_manager.py
+++ b/steelclaw/security/sudo_manager.py
@@ -15,9 +15,11 @@ import fnmatch
 import logging
 import os
 import shlex
+import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Optional
 
 from steelclaw.security.permission_models import (
     PermissionDecision,
@@ -65,6 +67,8 @@ class SudoManager:
         self._audit_path = Path(sudo_config.audit_log).expanduser().resolve()
         self._confirm_callback: SudoConfirmCallback | None = None
         self._broadcaster: "PermissionBroadcaster | None" = None
+        # Per-session sudo password cache: session_id → (password, expires_at)
+        self._password_cache: dict[str, tuple[str, float]] = {}
 
     def set_confirm_callback(self, callback: SudoConfirmCallback) -> None:
         """Register the async callback used to prompt the user for confirmation.
@@ -141,8 +145,17 @@ class SudoManager:
             try:
                 decision = await self._broadcaster.broadcast_request(request)
                 if decision in (PermissionDecision.APPROVE_ONCE, PermissionDecision.APPROVE_SESSION):
+                    # Obtain sudo password (from cache or via popup)
+                    password = await self._get_sudo_password(
+                        session_id=session_id,
+                        command=command,
+                        timeout=timeout,
+                    )
+                    if password is None:
+                        self._write_audit("DENIED (no password)", command)
+                        return "sudo command cancelled: no password provided"
                     self._write_audit("APPROVED", command)
-                    return await self._run_sudo(command, timeout)
+                    return await self._run_sudo(command, timeout, password=password)
                 else:
                     self._write_audit("DENIED (user)", command)
                     return "sudo command denied by user"
@@ -155,48 +168,69 @@ class SudoManager:
                 self._write_audit("ERROR", command)
                 return f"Error: sudo confirmation failed: {e}"
 
-        # Fallback to legacy callback if available
-        if self._confirm_callback is None:
-            self._write_audit("DENIED (no callback)", command)
-            return (
-                "Error: sudo confirmation channel is not available. "
-                "Cannot execute privileged commands without user approval."
-            )
-
-        prompt = (
-            f"⚠️  **Sudo command requested**\n"
-            f"`sudo {command}`\n\n"
-            f"Type **YES** (exactly, uppercase) to confirm, or anything else to cancel:"
+        self._write_audit("DENIED (no approval channel)", command)
+        return (
+            "Error: sudo confirmation channel is not available. "
+            "Cannot execute privileged commands without user approval."
         )
 
-        try:
-            response = await asyncio.wait_for(
-                self._confirm_callback(prompt),
-                timeout=float(timeout),
+    async def _get_sudo_password(
+        self,
+        session_id: str,
+        command: str,
+        timeout: int,
+    ) -> Optional[str]:
+        """Return a valid sudo password, using the session cache when still fresh.
+
+        If the cached password has expired (or was never set), requests a new
+        one from the user via the broadcaster's sudo password popup.
+        On success, stores the new password in the cache for *session_timeout*
+        seconds (from settings).
+        """
+        # Check in-memory cache
+        cached = self._password_cache.get(session_id)
+        if cached:
+            password, expires_at = cached
+            if time.monotonic() < expires_at:
+                logger.debug("Using cached sudo password for session %s", session_id)
+                return password
+            # Expired — remove stale entry
+            del self._password_cache[session_id]
+
+        if not self._broadcaster:
+            return None
+
+        request_id = str(uuid.uuid4())
+        password = await self._broadcaster.request_sudo_password(
+            request_id=request_id,
+            command=f"sudo {command}",
+            timeout_seconds=timeout,
+            context="Enter your sudo password to authenticate",
+        )
+
+        if password:
+            session_timeout = getattr(self._config, "session_timeout", 300)
+            self._password_cache[session_id] = (
+                password,
+                time.monotonic() + session_timeout,
             )
-        except asyncio.TimeoutError:
-            self._write_audit("DENIED (timeout)", command)
-            logger.warning("Sudo confirmation timed out for: %s", command[:80])
-            return f"Error: sudo confirmation timed out after {timeout}s"
+            logger.info(
+                "Sudo password cached for session %s (expires in %ds)",
+                session_id,
+                session_timeout,
+            )
 
-        # Strict "YES" check — no case folding, no trimming beyond stripping newlines
-        confirmed = isinstance(response, str) and response.strip() == "YES"
+        return password
 
-        if not confirmed:
-            self._write_audit("DENIED (user)", command)
-            logger.info("User denied sudo command: %s", command[:80])
-            return "sudo command denied: confirmation required (type YES to approve)"
-
-        self._write_audit("APPROVED", command)
-        return await self._run_sudo(command, timeout)
-
-    async def _run_sudo(self, command: str, timeout: int) -> str:
+    async def _run_sudo(self, command: str, timeout: int, password: Optional[str] = None) -> str:
         """Run a sudo command using exec (not shell) to prevent injection.
 
         The command is parsed with ``shlex.split()`` and passed as an argument
         list to ``create_subprocess_exec``.  This prevents shell metacharacters
         in *command* (e.g. ``;``, ``&&``, ``|``) from being interpreted by a
         shell.  Environment is sanitised to avoid credential leakage.
+        When *password* is provided the ``-S`` flag is used so sudo reads the
+        password from stdin — no TTY is required in that case.
         Output is truncated at ``_MAX_OUTPUT`` characters to prevent memory
         exhaustion from verbose commands.
         """
@@ -205,10 +239,17 @@ class SudoManager:
         except ValueError as e:
             return f"Error: Could not parse sudo command: {e}"
 
+        sudo_args = ["sudo"]
+        stdin_data: Optional[bytes] = None
+        if password is not None:
+            sudo_args.extend(["-S", "-p", ""])  # -S reads from stdin, -p "" suppresses prompt
+            stdin_data = (password + "\n").encode()
+
         try:
             process = await asyncio.create_subprocess_exec(
-                "sudo",
+                *sudo_args,
                 *args,
+                stdin=asyncio.subprocess.PIPE if stdin_data else None,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_get_sanitised_env(),
@@ -216,7 +257,7 @@ class SudoManager:
 
             try:
                 stdout, stderr = await asyncio.wait_for(
-                    process.communicate(),
+                    process.communicate(input=stdin_data),
                     timeout=timeout,
                 )
             except asyncio.TimeoutError:

--- a/steelclaw/web/static/index.html
+++ b/steelclaw/web/static/index.html
@@ -614,6 +614,31 @@ body {
 #permission-modal-box h3 { font-size:18px; margin-bottom:8px; display:flex; align-items:center; gap:8px; }
 #permission-modal-box .btn-success { background:var(--green); color:#fff; }
 #permission-modal-box .btn-success:hover { filter:brightness(1.1); }
+#perm-modal-timeout { font-size:11px; color:var(--text-dim); margin-bottom:16px; }
+#perm-timeout-remaining { font-weight:600; }
+
+/* ── Sudo Password Modal ─────────────────── */
+#sudo-modal {
+  display:none; position:fixed; top:0; left:0; right:0; bottom:0; z-index:1101;
+  background:var(--overlay-bg); justify-content:center; align-items:center; backdrop-filter:blur(8px);
+}
+#sudo-modal.open { display:flex; }
+#sudo-modal-box {
+  width:480px; max-width:90vw;
+  background:var(--glass-elevated); backdrop-filter:blur(30px); -webkit-backdrop-filter:blur(30px);
+  border:1px solid var(--glass-border); border-radius:20px;
+  padding:32px; box-shadow:0 24px 64px rgba(0,0,0,0.5);
+  animation:fadeInUp 0.3s ease-out;
+}
+#sudo-modal-box h3 { font-size:18px; margin-bottom:8px; display:flex; align-items:center; gap:8px; }
+#sudo-password-input {
+  width:100%; padding:10px 14px; border-radius:10px; border:1px solid var(--glass-border);
+  background:var(--input-bg); color:var(--text-primary); font-size:14px;
+  font-family:inherit; outline:none; box-sizing:border-box; margin-top:8px;
+}
+#sudo-password-input:focus { border-color:var(--accent); box-shadow:0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent); }
+#sudo-modal-timeout { font-size:11px; color:var(--text-dim); margin-bottom:16px; }
+#sudo-timeout-remaining { font-weight:600; }
 
 /* ── Settings Tabbed Layout ──────────────── */
 .settings-layout { display:flex; gap:20px; min-height:100%; }
@@ -870,35 +895,40 @@ body {
 <div id="permission-modal" onclick="if(event.target===this)closePermissionModal()">
   <div id="permission-modal-box">
     <h3>🔒 Permission Request</h3>
-    <div id="perm-modal-command" style="font-family:'JetBrains Mono',monospace;font-size:13px;background:var(--input-bg);padding:12px;border-radius:8px;margin:12px 0;overflow-x:auto;"></div>
-    <div id="perm-modal-context" style="color:var(--text-secondary);font-size:12px;margin-bottom:12px;"></div>
-    <div id="perm-modal-timeout" style="color:var(--text-dim);font-size:11px;margin-bottom:16px;">Timeout: <span id="perm-timeout-remaining">300</span>s</div>
-    <div class="modal-actions" style="display:flex;gap:8px;justify-content:center;">
-      <button class="btn btn-success" onclick="respondPermission('approve_once')">✓ Approve Once</button>
-      <button class="btn btn-primary" onclick="respondPermission('approve_session')">✓ Approve Session</button>
-      <button class="btn btn-danger" onclick="respondPermission('deny')">✕ Deny</button>
-    </div>
-  </div>
-</div>
-
-<div id="toast"></div>
-
-<!-- Permission Modal -->
-<div id="permission-modal" onclick="if(event.target===this)closePermissionModal()">
-  <div id="permission-modal-box">
-    <h3>🔒 Permission Request</h3>
     <div class="modal-desc" id="perm-modal-desc">A command needs your approval.</div>
     <div id="perm-modal-command" style="font-family:'JetBrains Mono',monospace;background:var(--input-bg);padding:12px;border-radius:8px;margin:12px 0;overflow-x:auto;white-space:pre-wrap;word-break:break-all;"></div>
     <div id="perm-modal-context" style="font-size:12px;color:var(--text-secondary);margin-bottom:12px;"></div>
-    <div id="perm-modal-timeout" style="font-size:11px;color:var(--text-dim);margin-bottom:16px;">Timeout: 300s</div>
+    <div id="perm-modal-timeout">Timeout: <span id="perm-timeout-remaining">300</span>s</div>
     <div class="modal-actions" style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap;">
-      <button class="btn btn-success" onclick="respondPermission('approve_once')">✅ Approve Once</button>
-      <button class="btn btn-primary" onclick="respondPermission('approve_session')">✅ Approve Session</button>
-      <button class="btn btn-danger" onclick="respondPermission('deny')">❌ Deny</button>
+      <button id="perm-btn-approve-once" class="btn btn-success" onclick="respondPermission('approve_once')">✅ Approve Once</button>
+      <button id="perm-btn-approve-session" class="btn btn-primary" onclick="respondPermission('approve_session')">✅ Approve Session</button>
+      <button id="perm-btn-deny" class="btn btn-danger" onclick="respondPermission('deny')">❌ Deny</button>
     </div>
     <div id="perm-modal-status" style="margin-top:12px;text-align:center;font-size:12px;display:none;"></div>
   </div>
 </div>
+
+<!-- Sudo Password Modal -->
+<div id="sudo-modal" onclick="if(event.target===this)closeSudoModal()">
+  <div id="sudo-modal-box">
+    <h3>🔐 Sudo Authentication</h3>
+    <div class="modal-desc" id="sudo-modal-desc">A privileged command requires your sudo password.</div>
+    <div id="sudo-modal-command" style="font-family:'JetBrains Mono',monospace;background:var(--input-bg);padding:12px;border-radius:8px;margin:12px 0;overflow-x:auto;white-space:pre-wrap;word-break:break-all;"></div>
+    <div id="sudo-modal-context" style="font-size:12px;color:var(--text-secondary);margin-bottom:8px;"></div>
+    <div id="sudo-modal-timeout">Session valid for: <span id="sudo-timeout-remaining">300</span>s</div>
+    <div class="form-group" style="margin-bottom:16px;">
+      <label style="font-size:13px;font-weight:500;">Sudo Password</label>
+      <input type="password" id="sudo-password-input" placeholder="Enter your sudo password" autocomplete="current-password" onkeydown="if(event.key==='Enter')submitSudoPassword()">
+    </div>
+    <div class="modal-actions" style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap;">
+      <button class="btn btn-outline btn-sm" onclick="closeSudoModal()">Cancel</button>
+      <button id="sudo-btn-submit" class="btn btn-primary" onclick="submitSudoPassword()">🔐 Authenticate</button>
+    </div>
+    <div id="sudo-modal-status" style="margin-top:12px;text-align:center;font-size:12px;display:none;"></div>
+  </div>
+</div>
+
+<div id="toast"></div>
 
 <script>
 // ── Helpers ───────────────────────────────────────────────
@@ -1089,6 +1119,10 @@ function wsConnect() {
       _handlePermissionResolved(d.data);
     } else if (etype === 'permission_response_ack') {
       // Acknowledgment received, update UI if needed
+    } else if (etype === 'sudo_password_request') {
+      _handleSudoPasswordRequest(d.data);
+    } else if (etype === 'sudo_password_resolved') {
+      _handleSudoPasswordResolved(d.data);
     } else {
       // Legacy non-streaming response (no type field)
       removeTyping();
@@ -1497,25 +1531,47 @@ function closeCredentialModal() { document.getElementById('credential-modal').cl
 
 // ── Permission Modal ───────────────────────────────────────
 let _pendingPermissionRequest = null;
+let _permCountdownTimer = null;
 
 function showPermissionModal(data) {
   _pendingPermissionRequest = data;
-  const modal = document.getElementById('permission-modal');
-  const cmdEl = document.getElementById('perm-modal-command');
-  const ctxEl = document.getElementById('perm-modal-context');
-  const timeoutEl = document.getElementById('perm-modal-timeout');
-  const statusEl = document.getElementById('perm-modal-status');
 
-  cmdEl.textContent = data.command || 'Unknown command';
-  ctxEl.textContent = data.context ? `Context: ${data.context}` : '';
-  timeoutEl.textContent = `Timeout: ${data.timeout_seconds || 300}s`;
-  statusEl.style.display = 'none';
-  statusEl.textContent = '';
+  document.getElementById('perm-modal-command').textContent = data.command || 'Unknown command';
+  document.getElementById('perm-modal-context').textContent = data.context ? `Context: ${data.context}` : '';
+  document.getElementById('perm-modal-status').style.display = 'none';
+  document.getElementById('perm-modal-status').textContent = '';
 
-  modal.classList.add('open');
+  // Re-enable buttons in case they were disabled from a previous request
+  _setPermissionButtons(true);
+
+  // Start countdown timer
+  let remaining = data.timeout_seconds || 300;
+  document.getElementById('perm-timeout-remaining').textContent = remaining;
+  clearInterval(_permCountdownTimer);
+  _permCountdownTimer = setInterval(() => {
+    remaining--;
+    const el = document.getElementById('perm-timeout-remaining');
+    if (el) el.textContent = remaining;
+    if (remaining <= 0) {
+      clearInterval(_permCountdownTimer);
+      _permCountdownTimer = null;
+      closePermissionModal();
+    }
+  }, 1000);
+
+  document.getElementById('permission-modal').classList.add('open');
+}
+
+function _setPermissionButtons(enabled) {
+  ['perm-btn-approve-once','perm-btn-approve-session','perm-btn-deny'].forEach(id => {
+    const btn = document.getElementById(id);
+    if (btn) btn.disabled = !enabled;
+  });
 }
 
 function closePermissionModal() {
+  clearInterval(_permCountdownTimer);
+  _permCountdownTimer = null;
   document.getElementById('permission-modal').classList.remove('open');
   _pendingPermissionRequest = null;
 }
@@ -1526,22 +1582,26 @@ function respondPermission(decision) {
   const requestId = _pendingPermissionRequest.request_id;
   const userId = localStorage.getItem('steelclaw-user-id') || 'web-' + Date.now();
 
-  // Send response via WebSocket
-  if (ws && ws.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify({
-      type: 'permission_response',
-      data: {
-        request_id: requestId,
-        decision: decision,
-        user_id: userId
-      }
-    }));
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    const statusEl = document.getElementById('perm-modal-status');
+    statusEl.style.display = 'block';
+    statusEl.innerHTML = '<span style="color:var(--red)">⚠️ Not connected. Reconnecting...</span>';
+    return;
   }
 
-  // Update modal to show we're waiting
+  // Disable buttons immediately so user can't double-click
+  _setPermissionButtons(false);
+  clearInterval(_permCountdownTimer);
+  _permCountdownTimer = null;
+
   const statusEl = document.getElementById('perm-modal-status');
   statusEl.style.display = 'block';
-  statusEl.textContent = 'Response sent, waiting for confirmation...';
+  statusEl.innerHTML = '<span style="opacity:0.7">⏳ Sending response...</span>';
+
+  ws.send(JSON.stringify({
+    type: 'permission_response',
+    data: { request_id: requestId, decision: decision, user_id: userId }
+  }));
 }
 
 function _handlePermissionRequest(data) {
@@ -1552,11 +1612,13 @@ function _handlePermissionResolved(data) {
   const modal = document.getElementById('permission-modal');
   if (!modal.classList.contains('open')) return;
 
+  clearInterval(_permCountdownTimer);
+  _permCountdownTimer = null;
+
   const statusEl = document.getElementById('perm-modal-status');
   statusEl.style.display = 'block';
-
   const decision = data.decision || 'unknown';
-  const resolvedBy = data.resolved_by || 'unknown';
+  const resolvedBy = data.resolved_by || 'system';
 
   if (decision === 'approve_once') {
     statusEl.innerHTML = `<span style="color:var(--green)">✅ Approved once by ${resolvedBy}</span>`;
@@ -1566,8 +1628,119 @@ function _handlePermissionResolved(data) {
     statusEl.innerHTML = `<span style="color:var(--red)">❌ Denied by ${resolvedBy}</span>`;
   }
 
-  // Auto-close after 2 seconds
   setTimeout(closePermissionModal, 2000);
+}
+
+// ── Sudo Password Modal ────────────────────────────────────
+let _pendingSudoRequest = null;
+let _sudoCountdownTimer = null;
+
+function showSudoModal(data) {
+  _pendingSudoRequest = data;
+
+  document.getElementById('sudo-modal-command').textContent = data.command || 'Unknown command';
+  document.getElementById('sudo-modal-context').textContent = data.context || '';
+  document.getElementById('sudo-modal-status').style.display = 'none';
+  document.getElementById('sudo-modal-status').textContent = '';
+  document.getElementById('sudo-password-input').value = '';
+
+  const btn = document.getElementById('sudo-btn-submit');
+  if (btn) btn.disabled = false;
+
+  // Start countdown
+  let remaining = data.timeout_seconds || 300;
+  const remEl = document.getElementById('sudo-timeout-remaining');
+  if (remEl) remEl.textContent = remaining;
+  clearInterval(_sudoCountdownTimer);
+  _sudoCountdownTimer = setInterval(() => {
+    remaining--;
+    const el = document.getElementById('sudo-timeout-remaining');
+    if (el) el.textContent = remaining;
+    if (remaining <= 0) {
+      clearInterval(_sudoCountdownTimer);
+      _sudoCountdownTimer = null;
+      closeSudoModal();
+    }
+  }, 1000);
+
+  document.getElementById('sudo-modal').classList.add('open');
+  setTimeout(() => document.getElementById('sudo-password-input').focus(), 100);
+}
+
+function closeSudoModal() {
+  clearInterval(_sudoCountdownTimer);
+  _sudoCountdownTimer = null;
+  document.getElementById('sudo-modal').classList.remove('open');
+  document.getElementById('sudo-password-input').value = '';
+  // If user closes without submitting, send cancellation
+  if (_pendingSudoRequest && ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({
+      type: 'sudo_password_response',
+      data: { request_id: _pendingSudoRequest.request_id, password: null }
+    }));
+  }
+  _pendingSudoRequest = null;
+}
+
+function submitSudoPassword() {
+  if (!_pendingSudoRequest) return;
+
+  const password = document.getElementById('sudo-password-input').value;
+  if (!password) {
+    const statusEl = document.getElementById('sudo-modal-status');
+    statusEl.style.display = 'block';
+    statusEl.innerHTML = '<span style="color:var(--red)">⚠️ Please enter your password.</span>';
+    return;
+  }
+
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    const statusEl = document.getElementById('sudo-modal-status');
+    statusEl.style.display = 'block';
+    statusEl.innerHTML = '<span style="color:var(--red)">⚠️ Not connected. Please try again.</span>';
+    return;
+  }
+
+  const btn = document.getElementById('sudo-btn-submit');
+  if (btn) btn.disabled = true;
+  clearInterval(_sudoCountdownTimer);
+  _sudoCountdownTimer = null;
+
+  const statusEl = document.getElementById('sudo-modal-status');
+  statusEl.style.display = 'block';
+  statusEl.innerHTML = '<span style="opacity:0.7">⏳ Authenticating...</span>';
+
+  ws.send(JSON.stringify({
+    type: 'sudo_password_response',
+    data: { request_id: _pendingSudoRequest.request_id, password: password }
+  }));
+}
+
+function _handleSudoPasswordRequest(data) {
+  showSudoModal(data);
+}
+
+function _handleSudoPasswordResolved(data) {
+  const modal = document.getElementById('sudo-modal');
+  if (!modal.classList.contains('open')) return;
+
+  clearInterval(_sudoCountdownTimer);
+  _sudoCountdownTimer = null;
+  document.getElementById('sudo-password-input').value = '';
+
+  const statusEl = document.getElementById('sudo-modal-status');
+  statusEl.style.display = 'block';
+
+  if (data.success) {
+    statusEl.innerHTML = '<span style="color:var(--green)">✅ Authenticated successfully</span>';
+  } else {
+    statusEl.innerHTML = '<span style="color:var(--red)">❌ Authentication failed or cancelled</span>';
+  }
+
+  // Close and clear sensitive state
+  _pendingSudoRequest = null;
+  setTimeout(() => {
+    document.getElementById('sudo-modal').classList.remove('open');
+  }, 1500);
 }
 
 async function configureSkill(name) {


### PR DESCRIPTION
- Web UI: remove duplicate #permission-modal that caused buttons to give no visible feedback (status text rendered in the hidden second copy)
- Web UI: disable approval buttons immediately on click, show live countdown timer, re-enable with error when WebSocket is disconnected
- Web UI: new sudo password modal — shown after sudo command is approved, user enters password which is cached per-session for session_timeout seconds (configurable in agents.security.sudo.session_timeout)
- Backend: SudoManager now requests password via broadcaster popup and runs sudo with -S flag to read password from stdin (no TTY needed)
- Backend: added broadcaster.request_sudo_password / resolve_sudo_password for the sudo password popup flow with its own timeout handling
- Backend: added sudo_password_response WebSocket handler in router.py
- Backend: fixed _broadcast_resolution to call send_permission_resolved (new method) instead of send_permission_request with empty chat_id
- Telegram: override send_permission_resolved to edit the inline-keyboard message when another channel resolves the permission (e.g. web UI)
- Removed legacy "Type YES" text confirmation fallback from sudo_manager

https://claude.ai/code/session_01BhX4Ec6XD2Xi9ETpdJUjqN