### PR TITLE
feat: add missing slash commands and enhance CLI UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,59 @@ steelclaw chat
 
 The TUI chat supports streaming responses — text appears token-by-token as the LLM generates it, with live tool-call status indicators and delegation banners for multi-agent workflows. Uses Rich for styled panels and Markdown rendering.
 
-**Slash command autocomplete:** Type `/` in the prompt to open an interactive inline dropdown of all available commands. Use arrow keys to navigate, Enter to select, Escape to dismiss. Typing narrows the list in real time (e.g. `/st` matches `/status` and `/stats`). Falls back to plain input in non-interactive (piped/CI) environments.
+**Slash command autocomplete:** Type `/` in the prompt to open an interactive inline dropdown of all available commands grouped by category. Use arrow keys to navigate, Enter to select, Escape to dismiss. Typing narrows the list in real time (e.g. `/sc` matches `/scheduler`, `/security`). Falls back to plain input in non-interactive (piped/CI) environments.
 
-Available commands: `/help`, `/clear`, `/status`, `/history`, `/compact`, `/model`, `/stats`, `/new`, `/export`, `/quit`.
+#### Chat-native commands (resolved inside the TUI, no server round-trip)
 
-**CLI passthrough commands:** Prefix any CLI subcommand with `/` to run it without leaving the chat (e.g. `/skills list`, `/memory search "error budget"`, `/connectors status`). Quoted arguments and paths with spaces are handled correctly via shell-aware parsing.
+| Command | Description |
+|---------|-------------|
+| `/help` | Show all commands, grouped by section |
+| `/clear` | Clear conversation history |
+| `/new` | Start a fresh conversation |
+| `/history` | Show full conversation history |
+| `/compact` | Show last 10 exchanges (compact) |
+| `/status` | Connection info — probes the REST `/health` endpoint live |
+| `/model` | Live LLM config (model, temperature, max tokens, streaming) |
+| `/stats` | Session statistics |
+| `/version` | SteelClaw package version and server URL |
+| `/pricing` | Model pricing table grouped by provider |
+| `/export [file]` | Export chat to a Markdown file |
+| `/exit` / `/quit` | Exit the chat |
+
+#### CLI passthrough commands (delegated to `steelclaw <subcommand>`)
+
+Prefix any CLI subcommand with `/` to run it without leaving the chat. Quoted arguments and paths with spaces are handled correctly via shell-aware parsing.
+
+| Command | Example | Description |
+|---------|---------|-------------|
+| `/serve` | `/serve` | Start the API server in foreground |
+| `/start` / `/stop` / `/restart` | | Daemon management |
+| `/app` | `/app restart` | Manage app components |
+| `/config` | `/config get agents.llm.default_model` | View/edit configuration |
+| `/sessions` | `/sessions list` | Manage sessions |
+| `/memory` | `/memory search "error budget"` | Manage persistent memory |
+| `/agents` | `/agents list` | Manage agents |
+| `/skills` | `/skills configure github` | Manage skills |
+| `/scheduler` | `/scheduler list` | Manage scheduled jobs |
+| `/security` | `/security list-rules` | Manage security settings |
+| `/sudo` | `/sudo enable` | Sudo mode shortcuts |
+| `/connectors` | `/connectors status telegram` | Manage connectors |
+| `/gateway` | `/gateway restart` | Manage gateway |
+| `/logs` | `/logs -f` | Follow daemon logs |
+| `/persona` | `/persona` | Configure agent persona |
+| `/onboard` / `/setup` | | Onboarding wizard |
+| `/migrate` | | Run database migrations |
+
+**`/sudo` shortcuts:**
+
+| Command | Maps to |
+|---------|---------|
+| `/sudo enable` | `steelclaw security sudo-enable true` |
+| `/sudo disable` | `steelclaw security sudo-enable false` |
+| `/sudo whitelist list` | `steelclaw security sudo-whitelist list` |
+| `/sudo whitelist add <pattern>` | `steelclaw security sudo-whitelist add <pattern>` |
+| `/sudo whitelist remove <pattern>` | `steelclaw security sudo-whitelist remove <pattern>` |
+| `/sudo status` | `steelclaw security show` |
 
 ## CLI Commands
 
@@ -103,6 +151,7 @@ Available commands: `/help`, `/clear`, `/status`, `/history`, `/compact`, `/mode
 | `steelclaw chat` | Interactive TUI chat |
 | `steelclaw onboard` | Interactive onboarding wizard |
 | `steelclaw setup` | Alias for `onboard` |
+| `steelclaw config show\|get\|set` | View/edit `config.json` via dot-notation keys |
 | `steelclaw sessions list\|reset\|delete` | Manage sessions |
 | `steelclaw agents list\|add\|delete\|status` | Manage agents (supports `--parent`, `--system-prompt`) |
 | `steelclaw skills list\|install\|enable\|disable\|configure` | Manage skills |
@@ -110,8 +159,57 @@ Available commands: `/help`, `/clear`, `/status`, `/history`, `/compact`, `/mode
 | `steelclaw persona` | Configure agent persona interactively |
 | `steelclaw logs [-f] [--gateway] [--app]` | View daemon logs |
 | `steelclaw migrate` | Run database migrations |
+| `steelclaw scheduler list\|add\|remove\|run\|set-timezone` | Manage scheduled jobs |
+| `steelclaw security show\|list-rules\|add-rule\|remove-rule\|sudo-*\|capabilities` | Manage security settings |
 | `steelclaw gateway start\|stop\|restart` | Manage gateway connectors |
-| `steelclaw app start\|stop\|restart` | Manage app components |
+| `steelclaw connectors list\|configure\|enable\|disable\|status` | Manage individual connectors |
+| `steelclaw app start\|stop\|restart\|reset` | Manage app components |
+
+### `steelclaw config` — Configuration CLI
+
+Read and write any `config.json` value without editing the file manually, using dot-notation keys:
+
+```bash
+# Show the full config with syntax highlighting
+steelclaw config show
+
+# Get a specific value
+steelclaw config get agents.llm.default_model
+steelclaw config get agents.security.sudo.enabled
+
+# Set a value (JSON-parsed: use true/false for booleans, numbers stay numeric)
+steelclaw config set agents.llm.default_model claude-sonnet-4-20250514
+steelclaw config set agents.llm.temperature 0.5
+steelclaw config set agents.security.sudo.enabled true
+steelclaw config set server.port 9000
+```
+
+Changes take effect after restarting the server (`steelclaw restart`).
+
+### `steelclaw scheduler` — Job Management
+
+```bash
+steelclaw scheduler list
+steelclaw scheduler add daily-report --cron "0 9 * * *" --command "generate report"
+steelclaw scheduler add heartbeat   --interval 300 --command "ping"
+steelclaw scheduler remove daily-report
+steelclaw scheduler run daily-report
+steelclaw scheduler set-timezone America/New_York
+```
+
+### `steelclaw security` — Security Settings
+
+```bash
+steelclaw security show
+steelclaw security list-rules
+steelclaw security add-rule "git *" --permission ignore --note "All git commands"
+steelclaw security remove-rule "git *"
+steelclaw security set-default ask|record|ignore
+steelclaw security sudo-enable true|false
+steelclaw security sudo-whitelist list|add|remove <pattern>
+steelclaw security capabilities
+steelclaw security set-capability file_deletion allow
+```
 
 ## Access Methods
 
@@ -793,17 +891,27 @@ Dangerous commands are always blocked regardless of approval rules. Configure in
 
 ## Scheduler
 
-Proactive task execution with cron jobs and reminders:
+Proactive task execution with cron expressions, fixed intervals, and event-based triggers (file watcher, RSS polling, API polling).
 
 ```bash
-# List scheduled jobs
-curl http://localhost:8000/api/scheduler/jobs
+# Via CLI
+steelclaw scheduler list
+steelclaw scheduler add daily-report --cron "0 9 * * *" --command "generate daily report"
+steelclaw scheduler add heartbeat --interval 300 --command "ping service"
+steelclaw scheduler remove daily-report
+steelclaw scheduler set-timezone America/New_York
+steelclaw scheduler set-max-concurrent 5
 
-# Check scheduler status
+# Via the chat TUI
+/scheduler list
+/scheduler add job1 --cron "0 9 * * *" --command "report"
+
+# Via REST API
+curl http://localhost:8000/api/scheduler/jobs
 curl http://localhost:8000/api/scheduler/status
 ```
 
-Jobs can be programmatically added via the Python API or through LLM tool calls.
+Jobs can also be added programmatically via the Python API or through LLM tool calls (the `cron_manager` skill provides `schedule_task`, `list_scheduled`, and `cancel_task` tools).
 
 ## REST API
 
@@ -900,6 +1008,9 @@ steelclaw/
     persona.py        Persona configuration wizard
     gateway_cmd.py    Gateway connector control
     app_cmd.py        App component management
+    config_cmd.py     Configuration CLI (show/get/set via dot-notation)
+    scheduler.py      Scheduler job management CLI
+    security.py       Security settings CLI (rules, sudo, capabilities)
   web/static/         Control UI dashboard (HTML/JS/CSS)
   db/
     engine.py         Async SQLAlchemy engine + auto-migration

--- a/steelclaw/__main__.py
+++ b/steelclaw/__main__.py
@@ -194,6 +194,15 @@ def cmd_security(args: argparse.Namespace) -> None:
     handle_security(args)
 
 
+# ── Config ───────────────────────────────────────────────────────────────────
+
+
+def cmd_config(args: argparse.Namespace) -> None:
+    """View/edit configuration."""
+    from steelclaw.cli.config_cmd import handle_config
+    handle_config(args)
+
+
 # ── Scheduler ────────────────────────────────────────────────────────────────
 
 
@@ -366,6 +375,16 @@ def main() -> None:
     # persona
     sub.add_parser("persona", help="Configure agent persona interactively")
 
+    # config
+    config_p = sub.add_parser("config", help="View/edit configuration (dot-notation keys)")
+    config_sub = config_p.add_subparsers(dest="config_action")
+    config_sub.add_parser("show", help="Show full config.json with syntax highlighting")
+    config_get_p = config_sub.add_parser("get", help="Get a config value by key")
+    config_get_p.add_argument("key", help="Dot-notation key (e.g. agents.llm.default_model)")
+    config_set_p = config_sub.add_parser("set", help="Set a config value by key")
+    config_set_p.add_argument("key", help="Dot-notation key (e.g. agents.llm.temperature)")
+    config_set_p.add_argument("value", help="Value (JSON-parsed: 'true'/'false' for booleans, numbers as ints/floats)")
+
     # security
     security_p = sub.add_parser("security", help="Manage security settings")
     security_sub = security_p.add_subparsers(dest="security_action")
@@ -428,6 +447,7 @@ def main() -> None:
         "connectors": cmd_connectors,
         "app": cmd_app_mgmt,
         "persona": cmd_persona,
+        "config": cmd_config,
         "security": cmd_security,
         "scheduler": cmd_scheduler,
     }

--- a/steelclaw/cli/chat.py
+++ b/steelclaw/cli/chat.py
@@ -29,46 +29,70 @@ THINKING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇"
 TOOL_FRAMES = ["◐", "◓", "◑", "◒"]
 CONNECT_FRAMES = ["◜ ", " ◝", " ◞", "◟ "]
 
-# ── Slash commands — single source of truth ────────────────────────────────
-# Grouped: chat-native commands first, then CLI passthrough commands.
+# ── Slash commands — grouped for display, flat for autocomplete ────────────
 
+# HELP_SECTIONS drives both the /help table (with section headers) and the
+# flat SLASH_COMMANDS list used by the autocompleter.
+HELP_SECTIONS: list[tuple[str, list[tuple[str, str]]]] = [
+    ("Chat", [
+        ("/help",        "Show available commands"),
+        ("/exit",        "Exit the chat"),
+        ("/quit",        "Exit the chat"),
+        ("/clear",       "Clear conversation history"),
+        ("/new",         "Start a new conversation"),
+        ("/history",     "Show full conversation history"),
+        ("/compact",     "Show recent history (last 10 exchanges)"),
+        ("/status",      "Connection, server and session info"),
+        ("/stats",       "Show session statistics"),
+        ("/model",       "Show current model info"),
+        ("/version",     "Show SteelClaw version"),
+        ("/export",      "Export chat to file  [filename]"),
+    ]),
+    ("Server / Daemon", [
+        ("/serve",       "Start the API server in foreground"),
+        ("/start",       "Start SteelClaw as background daemon"),
+        ("/stop",        "Stop the background daemon"),
+        ("/restart",     "Restart the background daemon"),
+        ("/app",         "Manage app  [start|stop|restart|reset]"),
+    ]),
+    ("Data & Configuration", [
+        ("/config",      "View/edit configuration  [show|get <key>|set <key> <val>]"),
+        ("/migrate",     "Run database migrations"),
+        ("/sessions",    "Manage sessions  [list|reset|delete]"),
+        ("/memory",      "Manage memory  [status|search|clear|experiences]"),
+        ("/agents",      "Manage agents  [list|add|delete|status]"),
+        ("/skills",      "Manage skills  [list|install|enable|disable|configure]"),
+        ("/persona",     "Configure agent persona interactively"),
+        ("/onboard",     "Run the interactive onboarding wizard"),
+        ("/setup",       "Alias for /onboard"),
+    ]),
+    ("Scheduler", [
+        ("/scheduler",   "Manage scheduled jobs  [list|add|remove|run|set-timezone]"),
+    ]),
+    ("Security", [
+        ("/security",    "Security settings  [show|list-rules|add-rule|capabilities]"),
+        ("/sudo",        "Sudo mode  [enable|disable|whitelist list|add|remove]"),
+    ]),
+    ("Infrastructure", [
+        ("/logs",        "View daemon logs  [-f to follow]"),
+        ("/gateway",     "Manage gateway  [start|stop|restart]"),
+        ("/connectors",  "Manage connectors  [list|configure|enable|disable|status]"),
+    ]),
+    ("Info", [
+        ("/pricing",     "Show model pricing table"),
+    ]),
+]
+
+# Flat list derived from HELP_SECTIONS — used by the autocompleter.
 SLASH_COMMANDS: list[tuple[str, str]] = [
-    # ── Chat-native ────────────────────────────────────────────────────
-    ("/help",        "Show available commands"),
-    ("/exit",        "Exit the chat"),
-    ("/quit",        "Exit the chat"),
-    ("/clear",       "Clear conversation history"),
-    ("/status",      "Connection and session info"),
-    ("/history",     "Show conversation history"),
-    ("/compact",     "Show history (compact, last 10)"),
-    ("/model",       "Show current model info"),
-    ("/stats",       "Show session statistics"),
-    ("/new",         "Start a new conversation"),
-    ("/export",      "Export chat to file"),
-    # ── Server / daemon ────────────────────────────────────────────────
-    ("/serve",       "Start the API server in foreground"),
-    ("/start",       "Start SteelClaw as background daemon"),
-    ("/stop",        "Stop the background daemon"),
-    ("/restart",     "Restart the background daemon"),
-    # ── Data & config ──────────────────────────────────────────────────
-    ("/migrate",     "Run database migrations"),
-    ("/sessions",    "Manage sessions  [list|reset|delete]"),
-    ("/memory",      "Manage persistent memory  [status|search|clear]"),
-    ("/agents",      "Manage agents  [list|add|delete|status]"),
-    ("/skills",      "Manage skills  [list|install|enable|disable|configure]"),
-    ("/persona",     "Configure agent persona interactively"),
-    ("/onboard",     "Run the interactive onboarding wizard"),
-    ("/setup",       "Alias for /onboard"),
-    # ── Infrastructure ─────────────────────────────────────────────────
-    ("/logs",        "View daemon logs  [-f to follow]"),
-    ("/gateway",     "Manage gateway connectors  [start|stop|restart]"),
-    ("/connectors",  "Manage connectors  [list|configure|enable|disable|status]"),
+    entry for _, cmds in HELP_SECTIONS for entry in cmds
 ]
 
 # Commands resolved entirely within the chat loop (no subprocess).
 _CHAT_NATIVE: frozenset[str] = frozenset({
     "/help", "/exit", "/quit", "/clear", "/status",
     "/history", "/compact", "/model", "/stats", "/new", "/export",
+    "/version", "/pricing",
 })
 
 # Commands delegated to `steelclaw <subcommand> [args]` as a subprocess.
@@ -76,6 +100,12 @@ _CLI_PASSTHROUGH: frozenset[str] = frozenset({
     "/serve", "/start", "/stop", "/restart", "/migrate",
     "/sessions", "/memory", "/agents", "/skills", "/logs",
     "/gateway", "/connectors", "/persona", "/onboard", "/setup",
+    "/scheduler", "/security", "/app", "/config",
+})
+
+# Commands with custom argument mapping (not simple name→subcommand).
+_SPECIAL_CMDS: frozenset[str] = frozenset({
+    "/sudo",
 })
 
 
@@ -172,12 +202,20 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
         print_banner()
 
     def _render_help() -> Panel:
-        tbl = Table(show_header=True, box=box.SIMPLE_HEAVY, padding=(0, 2))
-        tbl.add_column("Command", style="accent", min_width=20)
+        tbl = Table(show_header=True, box=box.SIMPLE_HEAVY, padding=(0, 2), show_edge=False)
+        tbl.add_column("Command", style="accent", min_width=16)
         tbl.add_column("Description", style="dim")
-        for cmd, desc in SLASH_COMMANDS:
-            tbl.add_row(cmd, desc)
-        tbl.add_row("Ctrl+C", "Exit immediately")
+
+        for i, (section_name, cmds) in enumerate(HELP_SECTIONS):
+            if i > 0:
+                tbl.add_section()
+            # Section header row
+            tbl.add_row(f"[dim italic]{section_name}[/]", "", end_section=True)
+            for cmd, desc in cmds:
+                tbl.add_row(cmd, desc)
+
+        tbl.add_section()
+        tbl.add_row("[dim]Ctrl+C[/dim]", "[dim]Exit immediately[/dim]")
         return Panel(tbl, title="[accent] Commands [/]", border_style="blue", box=box.ROUNDED)
 
     def _render_message(role: str, content: str, ts: str = "") -> Panel:
@@ -203,20 +241,106 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
             padding=(0, 1),
         )
 
-    def _render_status(url: str, uid: str, connected: bool) -> Panel:
+    def _render_status(url: str, uid: str, ws_connected: bool) -> Panel:
+        # Derive the HTTP base URL from the WebSocket URL
+        http_base = url.replace("ws://", "http://").replace("wss://", "https://")
+        # Strip the WebSocket path to get the API root
+        for suffix in ("/gateway/ws", "/ws"):
+            if http_base.endswith(suffix):
+                http_base = http_base[: -len(suffix)]
+                break
+
+        # Probe the health endpoint
+        api_online = False
+        api_version = None
+        try:
+            import httpx as _httpx
+            resp = _httpx.get(f"{http_base}/health", timeout=2.0)
+            if resp.status_code == 200:
+                api_online = True
+                try:
+                    api_version = resp.json().get("version")
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
         tbl = Table(show_header=False, box=None, padding=(0, 2))
         tbl.add_column(style="dim", min_width=14)
         tbl.add_column()
         tbl.add_row("Server", f"[accent]{url}[/]")
         tbl.add_row("User", f"[accent]{uid}[/]")
-        status_str = "[success]● Connected[/]" if connected else "[error]● Disconnected[/]"
-        tbl.add_row("Status", status_str)
+        ws_str = "[success]● Connected[/]" if ws_connected else "[error]● Disconnected[/]"
+        api_str = (
+            f"[success]● Online[/] [dim]v{api_version}[/]" if api_online and api_version
+            else "[success]● Online[/]" if api_online
+            else "[error]● Unreachable[/]"
+        )
+        tbl.add_row("WebSocket", ws_str)
+        tbl.add_row("REST API", api_str)
         tbl.add_row("Mode", "[accent]Streaming[/]")
         uptime = int(time.time() - start_time)
         mins, secs = divmod(uptime, 60)
         tbl.add_row("Uptime", f"[dim]{mins}m {secs}s[/]")
         tbl.add_row("Messages", f"[dim]{msg_count}[/]")
         return Panel(tbl, title="[accent] Status [/]", border_style="blue", box=box.ROUNDED)
+
+    def _render_version(url: str) -> Panel:
+        try:
+            from importlib.metadata import version as pkg_ver
+            v = pkg_ver("steelclaw")
+        except Exception:
+            try:
+                from steelclaw import __version__
+                v = __version__
+            except Exception:
+                v = "unknown"
+
+        tbl = Table(show_header=False, box=None, padding=(0, 2))
+        tbl.add_column(style="dim", min_width=14)
+        tbl.add_column()
+        tbl.add_row("Package", "[accent]steelclaw[/]")
+        tbl.add_row("Version", f"[bold accent]{v}[/]")
+        tbl.add_row("Interface", "[accent]WebSocket TUI[/]")
+        tbl.add_row("Server", f"[dim]{url}[/]")
+        return Panel(tbl, title="[accent] Version [/]", border_style="blue", box=box.ROUNDED)
+
+    def _render_pricing() -> Panel:
+        from steelclaw.pricing import MODEL_PRICING
+
+        tbl = Table(show_header=True, box=box.SIMPLE_HEAVY, padding=(0, 2), show_edge=False)
+        tbl.add_column("Model", style="accent", min_width=36)
+        tbl.add_column("Prompt / 1K", style="green", justify="right", min_width=14)
+        tbl.add_column("Completion / 1K", style="yellow", justify="right", min_width=16)
+
+        # Group by provider prefix
+        _providers: dict[str, list] = {}
+        for model, prices in MODEL_PRICING.items():
+            if "/" in model:
+                provider = model.split("/")[0].title()
+            elif model.startswith("claude"):
+                provider = "Anthropic"
+            elif model.startswith(("gpt", "o1", "o3")):
+                provider = "OpenAI"
+            else:
+                provider = "Other"
+            _providers.setdefault(provider, []).append((model, prices))
+
+        first = True
+        for provider, models in _providers.items():
+            if not first:
+                tbl.add_section()
+            first = False
+            tbl.add_row(f"[dim italic]{provider}[/]", "", "", end_section=True)
+            for model, prices in models:
+                short_model = model.split("/")[-1] if "/" in model else model
+                tbl.add_row(
+                    short_model,
+                    f"${prices['prompt']:.5f}",
+                    f"${prices['completion']:.5f}",
+                )
+
+        return Panel(tbl, title="[accent] Model Pricing (USD) [/]", border_style="blue", box=box.ROUNDED)
 
     def _render_stats() -> Panel:
         tbl = Table(show_header=False, box=None, padding=(0, 2))
@@ -324,21 +448,60 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
                 if not messages:
                     console.print("[dim]  No messages yet.[/dim]")
                 else:
-                    recent = messages[-20:]  # last 10 exchanges
+                    recent = messages[-20:]  # last 10 exchanges (20 messages = 10 user+assistant pairs)
+                    console.print(f"[dim]  Showing last {len(recent)} messages[/dim]\n")
                     for m in recent:
-                        role_tag = "[cyan]You[/]" if m["role"] == "user" else "[green]SC[/]"
+                        role_tag = "[cyan]You[/]" if m["role"] == "user" else "[green]SC [/]"
                         preview = m["content"][:120].replace("\n", " ")
+                        if len(m["content"]) > 120:
+                            preview += "…"
                         ts = m.get("time", "")
-                        console.print(f"  [dim]{ts}[/] {role_tag}: {preview}")
+                        console.print(f"  [dim]{ts}[/] {role_tag}  {preview}")
                 continue
 
             if cmd == "/model":
-                console.print("[dim]  Model info is determined server-side. Check /status on the web UI.[/dim]")
+                # Derive HTTP base URL and fetch live LLM config from the server
+                _http_base = server_url.replace("ws://", "http://").replace("wss://", "https://")
+                for _sfx in ("/gateway/ws", "/ws"):
+                    if _http_base.endswith(_sfx):
+                        _http_base = _http_base[: -len(_sfx)]
+                        break
+                try:
+                    import httpx as _httpx
+                    _resp = _httpx.get(f"{_http_base}/api/config/llm", timeout=3.0)
+                    if _resp.status_code == 200:
+                        _llm = _resp.json().get("llm", {})
+                        _tbl = Table(show_header=False, box=None, padding=(0, 2))
+                        _tbl.add_column(style="dim", min_width=18)
+                        _tbl.add_column()
+                        _tbl.add_row("Model", f"[bold accent]{_llm.get('default_model', '—')}[/]")
+                        _tbl.add_row("Temperature", f"[dim]{_llm.get('temperature', '—')}[/]")
+                        _tbl.add_row("Max tokens", f"[dim]{_llm.get('max_tokens', '—')}[/]")
+                        _tbl.add_row("Context msgs", f"[dim]{_llm.get('max_context_messages', '—')}[/]")
+                        _tbl.add_row("Streaming", f"[dim]{_llm.get('streaming', '—')}[/]")
+                        console.print(Panel(
+                            _tbl,
+                            title="[accent] Model [/]",
+                            border_style="blue",
+                            box=box.ROUNDED,
+                        ))
+                    else:
+                        console.print("[dim]  Could not retrieve model info (server returned non-200).[/dim]")
+                except Exception:
+                    console.print("[dim]  Model info unavailable — is the server running? Try /status[/dim]")
                 continue
 
             if cmd == "/new":
                 messages.clear()
                 console.print("[dim]  New conversation started.[/dim]\n")
+                continue
+
+            if cmd == "/version":
+                console.print(_render_version(server_url))
+                continue
+
+            if cmd == "/pricing":
+                console.print(_render_pricing())
                 continue
 
             if cmd_name == "/export":
@@ -352,6 +515,36 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
                     console.print(f"[success]  ✓ Exported to {fname}[/success]")
                 except Exception as e:
                     console.print(f"[error]  ✗ Export failed: {e}[/error]")
+                continue
+
+            if cmd_name == "/sudo":
+                # Map /sudo sub-args to steelclaw security sudo-* commands
+                sudo_parts = shlex.split(cmd_parts[1]) if len(cmd_parts) > 1 else []
+                sub = sudo_parts[0].lower() if sudo_parts else ""
+
+                if sub == "enable":
+                    cli_cmd = ["steelclaw", "security", "sudo-enable", "true"]
+                elif sub == "disable":
+                    cli_cmd = ["steelclaw", "security", "sudo-enable", "false"]
+                elif sub == "whitelist":
+                    wl_action = sudo_parts[1] if len(sudo_parts) > 1 else "list"
+                    cli_cmd = ["steelclaw", "security", "sudo-whitelist", wl_action]
+                    if len(sudo_parts) > 2:
+                        cli_cmd.append(sudo_parts[2])
+                elif sub == "status" or sub == "show" or sub == "":
+                    cli_cmd = ["steelclaw", "security", "show"]
+                else:
+                    console.print(
+                        "[error]  Usage:[/error] [accent]/sudo[/accent] "
+                        "[dim]enable | disable | whitelist [list|add|remove <pattern>] | status[/dim]"
+                    )
+                    continue
+
+                console.print(f"[dim]  Running:[/dim] [accent]{' '.join(cli_cmd)}[/accent]\n")
+                await asyncio.get_event_loop().run_in_executor(
+                    None, lambda c=cli_cmd: subprocess.run(c)
+                )
+                console.print()
                 continue
 
             if cmd_name in _CLI_PASSTHROUGH:

--- a/steelclaw/cli/chat.py
+++ b/steelclaw/cli/chat.py
@@ -109,6 +109,20 @@ _SPECIAL_CMDS: frozenset[str] = frozenset({
 })
 
 
+def _ws_to_http_base(ws_url: str) -> str:
+    """Convert a WebSocket URL to its HTTP base (scheme + host + port, no path).
+
+    Uses urllib.parse so the scheme substitution is safe even when the
+    protocol string appears elsewhere in the URL (e.g. as part of a hostname).
+    """
+    from urllib.parse import urlparse, urlunparse
+
+    parsed = urlparse(ws_url)
+    scheme = "https" if parsed.scheme == "wss" else "http"
+    # Keep only scheme + netloc; drop path/query/fragment
+    return urlunparse((scheme, parsed.netloc, "", "", "", ""))
+
+
 # ── prompt_toolkit autocomplete ────────────────────────────────────────────
 
 def _build_prompt_session():
@@ -241,27 +255,21 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
             padding=(0, 1),
         )
 
-    def _render_status(url: str, uid: str, ws_connected: bool) -> Panel:
-        # Derive the HTTP base URL from the WebSocket URL
-        http_base = url.replace("ws://", "http://").replace("wss://", "https://")
-        # Strip the WebSocket path to get the API root
-        for suffix in ("/gateway/ws", "/ws"):
-            if http_base.endswith(suffix):
-                http_base = http_base[: -len(suffix)]
-                break
-
-        # Probe the health endpoint
+    async def _render_status(url: str, uid: str, ws_connected: bool) -> Panel:
+        # Probe the health endpoint without blocking the event loop
+        http_base = _ws_to_http_base(url)
         api_online = False
         api_version = None
         try:
             import httpx as _httpx
-            resp = _httpx.get(f"{http_base}/health", timeout=2.0)
-            if resp.status_code == 200:
-                api_online = True
-                try:
-                    api_version = resp.json().get("version")
-                except Exception:
-                    pass
+            async with _httpx.AsyncClient() as _client:
+                _resp = await _client.get(f"{http_base}/health", timeout=2.0)
+                if _resp.status_code == 200:
+                    api_online = True
+                    try:
+                        api_version = _resp.json().get("version")
+                    except Exception:
+                        pass
         except Exception:
             pass
 
@@ -429,7 +437,7 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
                 continue
 
             if cmd == "/status":
-                console.print(_render_status(server_url, user_id, True))
+                console.print(await _render_status(server_url, user_id, True))
                 continue
 
             if cmd == "/stats":
@@ -460,15 +468,12 @@ async def _chat_loop(server_url: str, user_id: str) -> None:
                 continue
 
             if cmd == "/model":
-                # Derive HTTP base URL and fetch live LLM config from the server
-                _http_base = server_url.replace("ws://", "http://").replace("wss://", "https://")
-                for _sfx in ("/gateway/ws", "/ws"):
-                    if _http_base.endswith(_sfx):
-                        _http_base = _http_base[: -len(_sfx)]
-                        break
+                # Fetch live LLM config from the server without blocking the event loop
+                _http_base = _ws_to_http_base(server_url)
                 try:
                     import httpx as _httpx
-                    _resp = _httpx.get(f"{_http_base}/api/config/llm", timeout=3.0)
+                    async with _httpx.AsyncClient() as _client:
+                        _resp = await _client.get(f"{_http_base}/api/config/llm", timeout=3.0)
                     if _resp.status_code == 200:
                         _llm = _resp.json().get("llm", {})
                         _tbl = Table(show_header=False, box=None, padding=(0, 2))

--- a/steelclaw/cli/config_cmd.py
+++ b/steelclaw/cli/config_cmd.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import tempfile
 from pathlib import Path
 
 from rich.console import Console
@@ -38,8 +40,27 @@ def _load_config() -> dict:
 
 
 def _save_config(config: dict) -> None:
+    """Write config atomically: write to a temp file then os.replace().
+
+    This prevents partial writes from corrupting config.json if the process
+    is interrupted mid-write (e.g. power loss, SIGKILL).
+    """
     path = _get_config_path()
-    path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(config, indent=2)
+    # NamedTemporaryFile in the same directory ensures os.replace is atomic
+    # (same filesystem), and delete=False lets us manage the file manually.
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _config_show() -> None:

--- a/steelclaw/cli/config_cmd.py
+++ b/steelclaw/cli/config_cmd.py
@@ -1,0 +1,113 @@
+"""CLI configuration management — show/get/set config values via dot-notation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.table import Table
+from rich import box
+
+console = Console()
+
+
+def handle_config(args: argparse.Namespace) -> None:
+    action = getattr(args, "config_action", None)
+    if action == "get":
+        _config_get(args.key)
+    elif action == "set":
+        _config_set(args.key, args.value)
+    else:
+        _config_show()
+
+
+def _get_config_path() -> Path:
+    from steelclaw.paths import PROJECT_ROOT
+    return PROJECT_ROOT / "config.json"
+
+
+def _load_config() -> dict:
+    path = _get_config_path()
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {}
+
+
+def _save_config(config: dict) -> None:
+    path = _get_config_path()
+    path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+
+def _config_show() -> None:
+    """Display the full config.json with syntax highlighting."""
+    path = _get_config_path()
+    if not path.exists():
+        console.print(f"[yellow]No config.json found at {path}[/yellow]")
+        console.print("[dim]Run 'steelclaw setup' to create a configuration.[/dim]")
+        return
+
+    content = path.read_text(encoding="utf-8")
+    syntax = Syntax(content, "json", theme="monokai", line_numbers=True)
+    console.print(Panel(
+        syntax,
+        title=f"[bold cyan] Config: {path} [/]",
+        border_style="blue",
+        box=box.ROUNDED,
+    ))
+
+
+def _config_get(key: str) -> None:
+    """Get a config value by dot-notation key (e.g. agents.llm.default_model)."""
+    config = _load_config()
+    parts = key.split(".")
+
+    current = config
+    for part in parts:
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            console.print(f"[red]Key not found: {key}[/red]")
+            console.print("[dim]Use 'steelclaw config show' to see all available keys.[/dim]")
+            return
+
+    if isinstance(current, (dict, list)):
+        syntax = Syntax(json.dumps(current, indent=2), "json", theme="monokai")
+        console.print(Panel(syntax, title=f"[bold cyan] {key} [/]", border_style="blue", box=box.ROUNDED))
+    else:
+        tbl = Table(show_header=False, box=None, padding=(0, 2))
+        tbl.add_column(style="dim", min_width=10)
+        tbl.add_column()
+        tbl.add_row("Key", f"[bold cyan]{key}[/]")
+        tbl.add_row("Value", f"[bold green]{current}[/]")
+        tbl.add_row("Type", f"[dim]{type(current).__name__}[/]")
+        console.print(Panel(tbl, title="[bold cyan] Config Value [/]", border_style="blue", box=box.ROUNDED))
+
+
+def _config_set(key: str, value: str) -> None:
+    """Set a config value by dot-notation key."""
+    config = _load_config()
+    parts = key.split(".")
+
+    # Try to parse value as JSON (handles booleans, ints, null, etc.)
+    try:
+        parsed_value = json.loads(value)
+    except json.JSONDecodeError:
+        parsed_value = value  # Keep as string
+
+    # Navigate to the parent dict, creating missing levels
+    current = config
+    for part in parts[:-1]:
+        if part not in current or not isinstance(current[part], dict):
+            current[part] = {}
+        current = current[part]
+
+    current[parts[-1]] = parsed_value
+    _save_config(config)
+
+    display_val = json.dumps(parsed_value) if not isinstance(parsed_value, str) else parsed_value
+    console.print(f"[green]✓[/] [bold cyan]{key}[/] = [bold]{display_val}[/]")
+    console.print("[dim]  Restart the server for changes to take effect.[/dim]")

--- a/steelclaw/cli/config_cmd.py
+++ b/steelclaw/cli/config_cmd.py
@@ -51,16 +51,14 @@ def _save_config(config: dict) -> None:
     # NamedTemporaryFile in the same directory ensures os.replace is atomic
     # (same filesystem), and delete=False lets us manage the file manually.
     fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(content)
         os.replace(tmp_path, path)
-    except Exception:
-        try:
+    finally:
+        if os.path.exists(tmp_path):
             os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
 
 
 def _config_show() -> None:


### PR DESCRIPTION
Add /scheduler, /security, /sudo, /app, /config, /version, /pricing slash commands to the chat TUI so all CLI capabilities are accessible without leaving the chat session.

New features:
- /scheduler  → passthrough to steelclaw scheduler [list|add|remove|run]
- /security   → passthrough to steelclaw security [show|list-rules|add-rule|…]
- /sudo       → smart mapper to steelclaw security sudo-* subcommands
                (/sudo enable|disable|whitelist list|add|remove)
- /app        → passthrough to steelclaw app [start|stop|restart|reset]
- /config     → passthrough to new steelclaw config [show|get|set]
- /version    → chat-native panel showing package version and server URL
- /pricing    → chat-native panel with provider-grouped model pricing table

New CLI command:
- steelclaw config show|get <key>|set <key> <val> Read/write config.json values via dot-notation keys

UX improvements:
- /help table now has section headers (Chat / Server / Data / Scheduler / Security / Infrastructure / Info) with add_section() dividers
- /status pings /health endpoint and reports REST API liveness + version
- /model fetches live LLM config from /api/config/llm (model, temperature, max_tokens, streaming) instead of directing users to the web UI
- /compact adds message count header and truncation ellipsis
- HELP_SECTIONS drives both the grouped help display and the flat SLASH_COMMANDS list used by the prompt_toolkit autocompleter

https://claude.ai/code/session_01S1uAyFt9o3udkQeEfVNyx9